### PR TITLE
Add initial Makefile

### DIFF
--- a/source_code/Makefile
+++ b/source_code/Makefile
@@ -1,3 +1,10 @@
+#
+# Makefile
+#
+# Created: 2014-01-29
+# Author: Mikael Albertsson
+#
+
 CC = avr-gcc
 OBJCOPY = avr-objcopy
 OBJDUMP = avr-objdump


### PR DESCRIPTION
Add a Makefile to build the target files and clean up.

I have yet to add targets for setting the fuse bits and programming the device with the image(s). It'd probably be nice to use GCC's dependency generation features to get better dependency tracking as well.
