### PR TITLE
Fix type in datatype, remove unused prototypes

### DIFF
--- a/source_code/src/OLEDMP/oledmp.c
+++ b/source_code/src/OLEDMP/oledmp.c
@@ -643,7 +643,7 @@ void oledScrollClear(uint8_t options)
     }
     else 
     {
-        for (unt8_t y=0; y<OLED_HEIGHT; y++) 
+        for (uint8_t y=0; y<OLED_HEIGHT; y++) 
         {
             oledSetWindow(0, y, OLED_WIDTH-1, y);
             oledWriteCommand(CMD_WRITE_RAM);

--- a/source_code/src/USB/usb_serial_hid.h
+++ b/source_code/src/USB/usb_serial_hid.h
@@ -138,11 +138,6 @@ int8_t usb_serial_putchar_nowait(uint8_t c);  // transmit a character, do not wa
 int8_t usb_serial_write(const uint8_t *buffer, uint16_t size); // transmit a buffer
 void usb_serial_flush_output(void);	// immediately transmit any buffered output
 
-void usb_putstr(const char *str);
-void usb_putstr_P(const char *str);
-int usb_printf(const char* fmt, ...) __attribute__((format(printf, 1, 2)));
-int usb_printf_P(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
-
 // serial parameters
 uint32_t usb_serial_get_baud(void);	// get the baud rate
 uint8_t usb_serial_get_stopbits(void);	// get the number of stop bits


### PR DESCRIPTION
I introduced a typo in one of the updates (unt8_t instead of uint8_t).  This fixes it and the app compiles now.

Also removed old prototypes from usb_serial_hid.h.
