### PR TITLE
Fix header name mismatch

### DIFF
--- a/source_code/src/CARD/smartcard.c
+++ b/source_code/src/CARD/smartcard.c
@@ -25,7 +25,7 @@
 #include <avr/interrupt.h>
 #include <util/delay.h>
 #include "smartcard.h"
-#include "entropy.h"
+#include "Entropy.h"
 #include "defines.h"
 #include <avr/io.h>
 #include "utils.h"

--- a/source_code/src/RNG/Entropy.c
+++ b/source_code/src/RNG/Entropy.c
@@ -19,7 +19,7 @@
 // Edit:
 // April 2014 - Changed Entropy.cpp to Entropy.c, cpp to c functions
 #include <util/atomic.h>
-#include <entropy.h>
+#include <Entropy.h>
 
 #define gWDT_buffer_SIZE 32
 #define WDT_POOL_SIZE 8

--- a/source_code/src/mooltipass.c
+++ b/source_code/src/mooltipass.c
@@ -36,7 +36,7 @@
 #include "flash_mem.h"
 #include "node_mgmt.h"
 #include "defines.h"
-#include "entropy.h"
+#include "Entropy.h"
 #include "oledmp.h"
 #include "utils.h"
 #include "tests.h"

--- a/source_code/src/tests.c
+++ b/source_code/src/tests.c
@@ -28,7 +28,7 @@
 #include "mooltipass.h"
 #include "flash_test.h"
 #include "defines.h"
-#include "entropy.h"
+#include "Entropy.h"
 #include "oledmp.h"
 #include "touch.h"
 


### PR DESCRIPTION
The code included entropy.h but it seems it should be Entropy.h.
