### PR TITLE
Fixed bug. Add backup/restore to updateParentNode

### DIFF
--- a/source_code/src/NODEMGMT/node_mgmt.c
+++ b/source_code/src/NODEMGMT/node_mgmt.c
@@ -948,13 +948,6 @@ RET_TYPE updateParentNode(mgmtHandle *h, pNode *p, uint16_t parentNodeAddress)
         {
             return ret;
         }
-
-        // rescan
-        ret = scanNextFreeParentNode(h, constructAddress(PAGE_PER_SECTOR, 0));
-        if(ret != RETURN_OK)
-        {
-            return ret;
-        }
     }
     return ret; 
 }


### PR DESCRIPTION
Please let me know if this fixes the mentioned bug.  I added comments to explain what this else bracket is doing.  I'm still having issues running on hardware.  hid_listen.exe just keeps spitting:

Waiting for new device:
Listening:

Device disconnected.
Waiting for new device:
Listening:

Device disconnected.

Indefinitely while the mooltipass is plugged in. (Both revs of hardware)
