### PR TITLE
Default to "unknown" if MOOLTIPASS_VERSION is not defined by build system

### DIFF
--- a/source_code/src/defines.h
+++ b/source_code/src/defines.h
@@ -207,7 +207,7 @@ typedef int8_t RET_TYPE;
 
 /**************** VERSION DEFINES ***************/
 #ifndef MOOLTIPASS_VERSION
-#warning "MOOLTIPASS_VERSION is not defined: Check your Makefile"
+#define MOOLTIPASS_VERSION "unknown"
 #endif
 
 /**************** BITMAP DEFINES ****************/

--- a/source_code/src/version.c
+++ b/source_code/src/version.c
@@ -23,6 +23,7 @@
 
 #include <avr/pgmspace.h>
 
+#include "defines.h"
 #include "version.h"
 
 static const char mooltipass_version[] PROGMEM = MOOLTIPASS_VERSION;


### PR DESCRIPTION
Tried like heck to get AtmelStudio to invoke git and get the proper answer, but no luck yet. In the mean time, this will keep things from breaking by defaulting to a crappy answer instead of broken code ;-)
