### PR TITLE
font.py: Fix issue w/ 1px wide characters

### DIFF
--- a/fonts/font.py
+++ b/fonts/font.py
@@ -121,7 +121,8 @@ def generateHeader(fontName, pngFilename, xmlFilename):
             lineWidth = 1
             pixels = 0
             pixCount = 0
-            for x in range(rect[0],rect[0]+rect[2]-1):
+            width = max(rect[2]-1,1)
+            for x in range(rect[0],rect[0]+width):
                 count += 1
                 # map 255 shades to 4
                 pix = line[y][x]['a'] >> (8-options.depth)
@@ -137,13 +138,14 @@ def generateHeader(fontName, pngFilename, xmlFilename):
 
                 patt += asciiPixel[pix]
 
-            count += 1
-            pix = line[y][x+1]['a'] >> (8-options.depth)
-            patt += asciiPixel[pix]
-            pixels = pixels << (options.depth) | pix
-            pixCount += 1
-            if pixCount < (8/options.depth):
-                pixels = pixels << ((8/options.depth)-pixCount)
+            if width > 1:
+                count += 1
+                pix = line[y][x+1]['a'] >> (8-options.depth)
+                patt += asciiPixel[pix]
+                pixels = pixels << (options.depth) | pix
+                pixCount += 1
+                if pixCount < (8/options.depth):
+                    pixels = pixels << ((8/options.depth)-pixCount)
             print >> outfd, '0x{:02x}, '.format(pixels),
             glyphData[ch].append(pixels & 0xFF)
             #glyphData[ch].append((pixels >> 8) & 0xFF)


### PR DESCRIPTION
Found the bug: when a glyph is only 1 pixel wide, the for loop at line 124 doesn't do anything. I *think* line 141 was supposed to make up for this, but doesn't quite do it. (There's probably a more elegant solution than mine, but it works ;-)

All of the 2px+ glyphs remain exactly the same, and now the 1px glyphs are filled in as expected. Using the following to invoke font.py, you can see the first 2 glyphs (! and "):
```bash
python2 ./font.py -n profontiix_regular_10_72 -p build/profontiix_regular_10_72.png -x build/profontiix_regular_10_72.xml
```
```C
const uint8_t profontiix_regular_10_72_0x21[] __attribute__((__progmem__)) = {   /* '!' width: 6 */
     0x03,          /* [*] */
     0x03,          /* [*] */
     0x03,          /* [*] */
     0x03,          /* [*] */
     0x03,          /* [*] */
     0x03,          /* [*] */
     0x00,          /* [ ] */
     0x03,          /* [*] */
};

const uint8_t profontiix_regular_10_72_0x22[] __attribute__((__progmem__)) = {   /* '"' width: 6 */
     0x66,          /* [* *] */
     0x66,          /* [* *] */
     0x66,          /* [* *] */
};
```