### PR TITLE
Fix some compiler warnings

### DIFF
--- a/source_code/src/FLASH/flash_test.c
+++ b/source_code/src/FLASH/flash_test.c
@@ -91,7 +91,7 @@ void initBuffer(uint8_t* buffer, uint16_t bufferSize, uint8_t policy)
 *     THIS TEST MUST BE RUN -> Sets up SPI
 *    \return   Test Status
 */
-RET_TYPE flashInitTest()
+RET_TYPE flashInitTest(void)
 {
     // simply call initFlash
     return initFlash();    
@@ -451,7 +451,7 @@ RET_TYPE flashEraseSectorZeroTest(uint8_t* bufferIn, uint8_t* bufferOut, uint16_
 /*!  \fn       displayInitForTest()
 *    \brief    Init OLED SCREEN per test
 */
-void displayInitForTest()
+void displayInitForTest(void)
 {
     #ifdef FLASH_TEST_DEBUG_OUTPUT_OLED
         oledClear();
@@ -520,7 +520,7 @@ void displayRWCode(RET_TYPE ret)
 /*!  \fn       displayPassed()
 *    \brief    Display PASSED Message (with delay)
 */
-void displayPassed()
+void displayPassed(void)
 {
     #ifdef FLASH_TEST_DEBUG_OUTPUT_OLED
         oledSetXY(0,16);
@@ -537,7 +537,7 @@ void displayPassed()
 /*!  \fn       displayFailed()
 *    \brief    Display FAILED Message
 */
-void displayFailed()
+void displayFailed(void)
 {
     #ifdef FLASH_TEST_DEBUG_OUTPUT_OLED
         oledSetXY(0,16);
@@ -552,7 +552,7 @@ void displayFailed()
 /*!  \fn       flashTest()
 *    \brief    Primary entry point for flash testing
 */
-RET_TYPE flashTest()
+RET_TYPE flashTest(void)
 {
     uint8_t inputBuffer[BYTES_PER_PAGE];
     uint8_t outputBuffer[BYTES_PER_PAGE];

--- a/source_code/src/FLASH/flash_test.h
+++ b/source_code/src/FLASH/flash_test.h
@@ -34,7 +34,7 @@
 
 void initBuffer(uint8_t* buffer, uint16_t bufferSize, uint8_t policy);
 
-RET_TYPE flashInitTest();
+RET_TYPE flashInitTest(void);
 
 RET_TYPE flashWriteReadTest(uint8_t* bufferIn, uint8_t* bufferOut, uint16_t bufferSize);
 RET_TYPE flashWriteReadOffsetTest(uint8_t* bufferIn, uint8_t* bufferOut, uint16_t bufferSize);
@@ -45,7 +45,7 @@ RET_TYPE flashEraseBlockTest(uint8_t* bufferIn, uint8_t* bufferOut, uint16_t buf
 RET_TYPE flashEraseSectorXTest(uint8_t* bufferIn, uint8_t* bufferOut, uint16_t bufferSize);
 RET_TYPE flashEraseSectorZeroTest(uint8_t* bufferIn, uint8_t* bufferOut, uint16_t bufferSize);
 
-RET_TYPE flashTest();
+RET_TYPE flashTest(void);
 
 
 // Flash Testing Defines

--- a/source_code/src/OLEDMP/oledmp.h
+++ b/source_code/src/OLEDMP/oledmp.h
@@ -141,11 +141,11 @@ void oledSetRowAddr(uint8_t start, uint8_t end);
 void oledSetScrollSpeed(uint8_t msecs);
 void oledFill(uint8_t colour);
 void stockOledFillXY(uint8_t x, int16_t y, uint16_t width, int8_t height, uint8_t colour);
-void stockOledClear();
+void stockOledClear(void);
 void stockOledClearLine(int16_t y);
 void oledScrollClear(uint8_t options);
 void oledScrollUp(uint8_t lines, bool clear);
-void oledReset();
+void oledReset(void);
 void stockOledOff(void);
 void stockOledOn(void);
 uint8_t stockOledIsOn(void);
@@ -187,7 +187,7 @@ void oledSetX(uint8_t col);
 void oledSetPixel(uint8_t x, uint8_t y, uint8_t colour);
 
 uint8_t oledGlyphWidth(char ch, uint8_t *indp, glyph_t *glyphp);
-uint8_t oledGlyphHeight();
+uint8_t oledGlyphHeight(void);
 uint8_t oledGlyphDraw(int16_t x, int16_t y, char ch, uint16_t colour, uint16_t bg);
 
 void stockOledPutch(char ch);


### PR DESCRIPTION
While developing I used dmbs which added `-Wstrict-prototypes`. This showed up some warnings that I resolved.