### PR TITLE
Update aes256_ctr.c

### DIFF
--- a/source_code/src/AES/aes256_ctr.c
+++ b/source_code/src/AES/aes256_ctr.c
@@ -218,7 +218,7 @@ void aes256CtrEncrypt(aes256CtrCtx_t *ctx, uint8_t *data, uint16_t dataLen)
 *	\brief	Decrypt data and save it in data.
 *
 *   \param  ctx - context
-*   \param  data - pointer to data, this is also the location to store encrypted data
+*   \param  data - pointer to data, this is also the location to store decrypted data
 *   \param  dataLen - size of data
 */
 void aes256CtrDecrypt(aes256CtrCtx_t *ctx, uint8_t *data, uint16_t dataLen)


### PR DESCRIPTION
If this function is just a wrapper to call the other encrypt function you can make it static always inline inside the header to save some more flash.