### PR TITLE
Added Startup Tables

### DIFF
--- a/source_code/src/AES/aes.h
+++ b/source_code/src/AES/aes.h
@@ -22,17 +22,30 @@
 #define __AES_H__
 
 #include <stdint.h>
+#if defined(__AVR__)
 #include <avr/pgmspace.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#define BACK_TO_TABLES
+//#define STARTUP_TABLES
 
 typedef struct {
     uint8_t key[32];
     uint8_t enckey[32];
     uint8_t deckey[32];
 } aes256_context;
+
+#if !defined(BACK_TO_TABLES) && defined(STARTUP_TABLES)
+#if defined(__AVR__)
+void aes256_init_sboxes(void) __attribute__ ((used, naked, section (".init5")));
+#else
+#error "This option is not available on non AVR platforms."
+#endif
+#endif
 
 void aes256_init_ecb(aes256_context *, uint8_t * /* key */);
 void aes256_done(aes256_context *);
@@ -41,14 +54,12 @@ void aes256_decrypt_ecb(aes256_context *, uint8_t * /* cipertext */);
 
 #define aes256_ctx_t aes256_context
 
-#define aes256_init(x,y)	aes256_init_ecb((y),(uint8_t*)(x))
-#define aes256_enc(x,y)		aes256_encrypt_ecb((y),(uint8_t*)(x))
-#define aes256_dec(x,y)		aes256_decrypt_ecb((y),(uint8_t*)(x))
+#define aes256_init(x,y)    aes256_init_ecb((y),(uint8_t*)(x))
+#define aes256_enc(x,y)     aes256_encrypt_ecb((y),(uint8_t*)(x))
+#define aes256_dec(x,y)     aes256_decrypt_ecb((y),(uint8_t*)(x))
 
 #ifdef __cplusplus
 }
 #endif
 
 #endif // __AES_H__
-
-


### PR DESCRIPTION
Also added PC side support of the library and some format fixes.

Added Small and Fast AES with higher RAM usage.
------------------------------------------------------------------

The fast AES uses lookup tables for faster enc/decrypt.
However those tables occupy 512 bytes of flash.

The slow AES generate the sbox values at runtime.
This uses less flash, but is very slow.

This solution generates the AES sbox tables at startup.
This way we can have fast lookup tables, but small flash usage.
The downside is a bigger RAM usage (512 bytes).
It also avoid progmem calls, which also improves the code size.
The sbox tables are automatically called at startup using init5 section.
This ensures that c++ constructurs have the sboxes available,
but is started after sram was initialized.
See http://www.nongnu.org/avr-libc/user-manual/mem_sections.html
This implementation uses around 50 bytes more flash than the slow AES.