### PR TITLE
Prevent "Failed to send to device: Transfer failed" error when device is suddenly unplugged

### DIFF
--- a/extension/background/event.js
+++ b/extension/background/event.js
@@ -211,10 +211,14 @@ event.mpUpdate = {};
 
 event.isMooltipassUnlocked = function()
 {
+	// prevents "Failed to send to device: Transfer failed" error when device is suddenly unplugged
+	if(typeof mooltipass.device._status.state == 'undefined'){
+		return false;
+	}
 
 	// Don't show notifications right now
 	console.log(mooltipass.device._status.state);
-	
+
 	// If the device is not connected and not unlocked and the user disabled the notifications, return
 	if (mooltipass.device._status.state != 'Unlocked')
 	{


### PR DESCRIPTION
This is difficult to reproduce, but the added code prevents the error message "Failed to send to device: Transfer failed" when the device is suddenly unplugged. 