### PR TITLE
Fixed lto bug with stackFree()

### DIFF
--- a/source_code/src/stack.c
+++ b/source_code/src/stack.c
@@ -53,7 +53,7 @@ extern uint8_t __stack;
 /*! \fn     stackInit(void)
 *   \brief  Function called at MCU start, to write a given value in the RAM
 */
-void stackInit(void) __attribute__ ((naked)) __attribute__ ((section (".init1")));
+void stackInit(void) __attribute__ ((naked, section (".init1"), used));
 
 void stackInit(void)
 {

--- a/source_code/src/stack.h
+++ b/source_code/src/stack.h
@@ -4,6 +4,6 @@
 #include <stdio.h>
 #include "defines.h"
 
-uint16_t stackFree(void);
+uint16_t stackFree(void) __attribute__ ((noinline));
 
 #endif


### PR DESCRIPTION
Might not work.

Other options:
* Disable optimization for this file
* [Do not compile stack.c with lto](https://stackoverflow.com/questions/25764582/is-it-possible-to-enable-link-time-optimization-while-only-disabling-strict-alia)
* Assembly