### PR TITLE
app.js: added emulator part for cancel

### DIFF
--- a/app/vendor/mooltipass/app.js
+++ b/app/vendor/mooltipass/app.js
@@ -95,9 +95,11 @@ mooltipass.app.onMessage = function(senderId, data, callbackFunction) {
     else if(inputObject.command == 'cancelGetCredentials')
     {
         console.log("Cancel request for reqid " + inputObject.reqid);
-        
-        // Cancel request only implemented in v1.1
-        if (mooltipass.util.getFirmwareFunctionalityVersionFromVersionString(mooltipass.device.version) >= "v1.1" && mooltipass.device.currentReqid == inputObject.reqid)
+        if ( 'undefined' !== typeof mooltipass.emulator.active && true === mooltipass.emulator.active ) 
+        {
+            mooltipass.emulator._cancelRequest( inputObject );
+        } 
+        else if (mooltipass.util.getFirmwareFunctionalityVersionFromVersionString(mooltipass.device.version) >= "v1.1" && mooltipass.device.currentReqid == inputObject.reqid)
         {
             // The cancel message doesn't generate any reply from the device, so we can just send it as is
             chrome.hid.send(mooltipass.device.connectionId, 0, mooltipass.device.createPacket(mooltipass.device.commands['cancelUserRequest'], null), function(){});

--- a/app/vendor/mooltipass/emulator.js
+++ b/app/vendor/mooltipass/emulator.js
@@ -48,20 +48,27 @@ mooltipass.emulator._getCredentials = function(inputObject) {
 
     console.log('Context:', firstContext[0] );
 	if ( 'undefined' !== typeof( firstContext[0] ) ) {
-		chrome.storage.local.get('mooltipass_emulator', function(result) {
-			console.log('mooltipass_emulator:', result.mooltipass_emulator );
-			credentials = result.mooltipass_emulator?JSON.parse(result.mooltipass_emulator):{};
-			var creds = {};
-			if ( 'undefined' !== typeof credentials[ firstContext[0] ] ) {
-				creds = credentials[ firstContext[0] ];
-				creds.success = true;
-			} else {
-				creds.success = false;
+		chrome.storage.local.get('mooltipass_emulator', function( result ) {
+			var creds = { success: false };
+			if ( result ) {
+				credentials = result.mooltipass_emulator?JSON.parse(result.mooltipass_emulator):{};
+				if ( 'undefined' !== typeof credentials[ firstContext[0] ] ) {
+					creds = credentials[ firstContext[0] ];
+					creds.success = true;
+				} 
 			}
-			console.log( 'credentials: ', creds );
-			inputObject.callbackFunction ( creds );
-		})
+			
+			this.timeout = setTimeout( function() { 
+				console.log( 'credentials for ' + firstContext[0] + ':', creds );
+				inputObject.callbackFunction ( creds );
+			},5000);
+		}.bind(this) );
 	} else {
 		inputObject.callbackFunction ( inputObject.callbackParameters );
 	}
 };
+
+mooltipass.emulator._cancelRequest = function(inputObject) {
+	console.log('CANCEL RETRIEVING CREDENTIALS *************************************************');
+	clearTimeout( this.timeout );
+}

--- a/app/vendor/mooltipass/interface.js
+++ b/app/vendor/mooltipass/interface.js
@@ -37,7 +37,7 @@ mooltipass.device.interface.metaCommands = [
 ];
 
 mooltipass.device.interface.send = function(inputObject) {
-    // console.log(inputObject);
+    //console.log('send', inputObject);
     var command = mooltipass.device.interface['_' + inputObject.command];
 
     // Emulation part

--- a/app/vendor/mooltipass/util.js
+++ b/app/vendor/mooltipass/util.js
@@ -3,6 +3,8 @@ mooltipass.util = mooltipass.util || {};
 
 mooltipass.util.getFirmwareFunctionalityVersionFromVersionString = function(version)
 {
+    if (!version) return 'error';
+    //console.log('Version:', version );
 	if (version.indexOf('_') == -1)
 	{
 		return version;

--- a/extension/background/browserAction.js
+++ b/extension/background/browserAction.js
@@ -11,9 +11,13 @@ browserAction.show = function(callback, tab) {
 	}
 
 	if(data.popup) {
-		chrome.browserAction.setPopup({
-			tabId: tab.id,
-			popup: "popups/" + data.popup
+		chrome.tabs.get(tab.id, function() {
+			if (!chrome.runtime.lastError) {
+				chrome.browserAction.setPopup({
+					tabId: tab.id,
+					popup: "popups/" + data.popup
+				});
+    		}
 		});
 	}
 }


### PR DESCRIPTION
emulator: added cancel code
interface: added a 'send' string to easily identify in console
util: added a checking for version (not related to task itself)
browserAction: added a check for the tab.id (sometimes it would throw a console error for tab id modified by chrome)
device: changed the call to onTabClosed from onTabUpdated. Now it goes: onTabUpdated -> onNavigatedAway -> onTabClosed.
device: Also commented out the timeout call (as I believe isn't needed anymore)