### PR TITLE
Alt version string and text-input bugfix

### DIFF
--- a/source_code/src/GUI/mini_gui_basic_functions.c
+++ b/source_code/src/GUI/mini_gui_basic_functions.c
@@ -371,6 +371,11 @@ RET_TYPE miniTextEntry(char * dst, uint8_t buflen, uint8_t filled_len, uint8_t m
                     miniOledNormalDisplay();
                     return RETURN_NOK;
                 }
+
+                /* handle default behaviour: backspace */
+                pos--;
+                dst[pos] = '\0';
+
                 /* clear text input and reset tracker if we have reached the required count of long clicks */
                 if(long_click_ctr >= ENTRY_LONGCLICK_ERASE)
                 {
@@ -381,9 +386,6 @@ RET_TYPE miniTextEntry(char * dst, uint8_t buflen, uint8_t filled_len, uint8_t m
                     }
                     pos = 0;
                 }
-                /* handle default behaviour: backspace */
-                pos--;
-                dst[pos] = '\0';
 
                 /* flash screen for 50 ms */
                 miniOledInvertedDisplay();

--- a/source_code/src/GUI/mini_gui_basic_functions.c
+++ b/source_code/src/GUI/mini_gui_basic_functions.c
@@ -336,6 +336,7 @@ RET_TYPE miniTextEntry(char * dst, uint8_t buflen, uint8_t filled_len, uint8_t m
                         /* erase previous char */
                         pos--;
                         dst[pos] = '\0';
+                        long_click_ctr=0;
 
                         /* flash screen for 50 ms */
                         miniOledInvertedDisplay();

--- a/source_code/src/GUI/mini_gui_smartcard_functions.c
+++ b/source_code/src/GUI/mini_gui_smartcard_functions.c
@@ -59,7 +59,11 @@ RET_TYPE guiDisplayInsertSmartCardScreenAndWait(void)
     #define BETA_TESTER_V
     #ifdef BETA_TESTER_V
         miniOledBitmapDrawFlash(0, 0, BITMAP_INSERT_CARD, OLED_SCROLL_NONE);
+        #ifdef MINI_CREDENTIAL_MANAGEMENT
+        miniOledPutCenteredString(21, "alt-beta v0.59");
+        #else
         miniOledPutCenteredString(21, "beta v0.59");
+        #endif
         miniOledFlushEntireBufferToDisplay();
     #else
         miniOledBitmapDrawFlash(0, 0, BITMAP_INSERT_CARD, OLED_SCROLL_FLIP);


### PR DESCRIPTION
- "alt-beta vx.xx" version string for on-device creds management firmware
- text input cancellation bugfix: long press now works as intended when the field was filled with some text before cancellation