### PR TITLE
Updated python tool readme for linux

### DIFF
--- a/tools/_python_framework/Readme.md
+++ b/tools/_python_framework/Readme.md
@@ -1,12 +1,5 @@
 # Mooltipass Python Tool
 
-## Installation on Ubuntu 16.04
-```
-sudo apt-get install python python-pip python-crypto
-pip install -r requirements.txt
-sudo python mooltipass_tool.py
-```
-
 ## Installation on Windows
 ### Downloads
 - Python 2.7.x from https://www.python.org/downloads/
@@ -33,14 +26,36 @@ sudo python mooltipass_tool.py
 - Select the 'vid:16d0 pid:09a0 rev:0100 mi:00' device, click 'Install'
 - Close the window
 
-## Arch Linux
+## Installation on Linux
+
+To access the device as normal user make sure you have set up the correct [udev rules](https://www.themooltipass.com/udev_rule.txt).
+
+### Ubuntu 16.04
+```
+sudo apt-get install python python-pip python-crypto
+pip install -r requirements.txt
+./mooltipass_tool.py
+```
+
+### Arch Linux
 
 From official repositories:
 ```
-python2 python2-crypto
+sudo pacman -S --needed python2 python2-crypto
 ```
 
 From AUR:
 ```
 python2-pyusb python2-intelhex python2-pyqrcode
+```
+
+### Other Linux Distributions
+
+Install `python2` and `pip` for you linux distribution.
+It is named `python2` or `python2` and `python2-pip` or `python-pip` in most cases.
+Then install all dependencies via pip:
+
+```
+pip install -r requirements.txt
+./mooltipass_tool.py
 ```


### PR DESCRIPTION
Followup of #222.

- [X] This PR is compliant with the contributing guidelines (if not, please describe why): code is fully documented and if possible a .md file is made.
- [X] The PR text includes a **detailed explanation** (more than 50 chars)
- [ ] I have thoroughly tested my contribution. -> Just a general readme change

Changes:
* Added udev link for linux -> removed dangerous sudo call of the tool
* Replaced `python mooltipass` with `./mooltipass`
* Added pacman command to Arch instruction
* Added section for other linux distributions
* Bundled linux instructions in its own section

You said my first instruction "did not work". What exactly did not work? You've added python2-crypto as dependency, but its already in the pip requirements list. So we can possibly remove the **distribution depenedency** to keep it consistent, as there is no user repository as on arch. This also allows to use the tool mostly on systems with no root rights if pip and python2 ist installed.