### PR TITLE
Possible FIX for Barracuda Equipment Login (just had the chance to us…

### DIFF
--- a/chrome_extension/background/init.js
+++ b/chrome_extension/background/init.js
@@ -215,7 +215,9 @@ var arrayBufferToData = {
 			var string = this.toString(arrayBuffer);
 			return JSON.parse(string);
 		} catch (e) {
-			return {};
+			// Failed to parse as JSON, try as URI encoded:
+			var string = this.toString(arrayBuffer);
+			return JSON.parse('{"' + decodeURI(string).replace(/"/g, '\\"').replace(/&/g, '","').replace(/=/g,'":"') + '"}');
 		}
 	}
 };


### PR DESCRIPTION
Quick fix for a report we received today:

- 10/4/2016 21:11:32
- https://x300/cgi-mod/index.cgi
- This is an internal login interface for the Barracuda X300 firewall appliance. Lastpass is able to see and populate the fields, but the Mooltipass extension doesn't even pop up on the context menu of the username and password fields. I tried to find the same issue on other Barracuda branded login pages, and it seems that the MP app works on all of the other pages, just not this one.	Open the login page for the Barracuda X300. 
- I can try to find ways to help you reproduce the error, but the page is by definition not internet accessible. I can send you the page source/anything else that could help you test the plugin. My email is briscuits@gmail.com.