### PR TITLE
Fixed display ghosting on a single page

### DIFF
--- a/source_code/src/OLEDMINI/oledmini.c
+++ b/source_code/src/OLEDMINI/oledmini.c
@@ -714,7 +714,16 @@ void miniOledBitmapDrawRaw(int8_t x, uint8_t y, bitstream_mini_t* bs)
             if (page == end_page)
             {
                 cur_pixels = miniBistreamGetNextByte(bs);
-                miniOledFrameBuffer[buffer_shift+x] &= rbitmask[data_rbitshift];
+                // Special case if we are only writing to a single page:
+                // Also keep the bits above(LSB) the pixels we write not only the one below.
+                if(end_page == start_page)
+                {
+                    miniOledFrameBuffer[buffer_shift+x] &= rbitmask[data_rbitshift] | ~rbitmask[data_rbitshift + pixels_to_be_displayed];
+                }
+                else
+                {
+                    miniOledFrameBuffer[buffer_shift+x] &= rbitmask[data_rbitshift];
+                }
                 miniOledFrameBuffer[buffer_shift+x] |= cur_pixels >> data_rbitshift;
                 pixels_to_be_displayed -= (8 - data_rbitshift);
             }


### PR DESCRIPTION
Fixes #261

- [X] This PR is compliant with the contributing guidelines (if not, please describe why): code is fully documented and if possible a .md file is made.
- [X] The PR text includes a **detailed explanation** (more than 50 chars)
- [X] I have thoroughly tested my contribution.

As described in the issue already there were some display ghosting with the characters " ^ ' ` in some rare situations. It turned out that this was only the case for this very thin and high characters (compared to 0 for example), as the only use 3 pixel at the very top.

The problem was that the `miniOledBitmapDrawRaw()` did not take into account that sometimes you are only writing to a single page of the OLED (8 bits per page). In this case the MSB data will be kept (the part below the character) but the upper part will be trashed (LSB).

So in my special testcase if I want to write to position 0,3 a character with 3,5 size (^) it will keep all data below (0, 6-7 aka 0xC0) and trash all above (0, 0-2 aka 0x03). The magic here was to also keep the upper part and add 0xC0 to 0x03 = 0xC3 et voila the upper and lower part is still existant.