### PR TITLE
Added no more free user slot warning

### DIFF
--- a/bitmaps/mini/fw_strings.txt
+++ b/bitmaps/mini/fw_strings.txt
@@ -75,7 +75,7 @@ Hash #2
 Change Description For:
 Do Not Unplug The Mini!
 One Try Remaining!
-RESERVED_7
+No more free user slot!
 RESERVED_8
 RESERVED_9
 Create Credentials

--- a/source_code/src/LOGIC/logic_fwflash_storage.h
+++ b/source_code/src/LOGIC/logic_fwflash_storage.h
@@ -280,6 +280,7 @@
     #define ID_STRING_CHANGE_DESC_FOR   74
     #define ID_STRING_DO_NOT_UNPLUG     75
     #define ID_STRING_LAST_PIN_TRY      76
+    #define ID_STRING_USER_NFREE        77
 
 #ifdef ENABLE_CREDENTIAL_MANAGEMENT
     /* reserved for main firmware branch usage

--- a/source_code/src/LOGIC/logic_smartcard.c
+++ b/source_code/src/LOGIC/logic_smartcard.c
@@ -125,8 +125,16 @@ RET_TYPE handleSmartcardInserted(void)
     }
     else if (detection_result == RETURN_MOOLTIPASS_BLANK)
     {
+        // Check if we have one more user slot available before we promt for a new pin
+        uint8_t userid, users_free;
+        if(findAvailableUserId(&userid, &users_free) != RETURN_OK)
+        {
+            // "No more free user slot!"
+            guiDisplayInformationOnScreen(ID_STRING_USER_NFREE);
+        }
+
         // This is a user free card, we can ask the user to create a new user inside the Mooltipass
-        if (guiAskForConfirmation(1, (confirmationText_t*)readStoredStringToBuffer(ID_STRING_NEWMP_USER)) == RETURN_OK)
+        else if (guiAskForConfirmation(1, (confirmationText_t*)readStoredStringToBuffer(ID_STRING_NEWMP_USER)) == RETURN_OK)
         {
             volatile uint16_t pin_code;
             


### PR DESCRIPTION
Fixes #269 
- [X] This PR is compliant with the contributing guidelines (if not, please describe why): code is fully documented and if possible a .md file is made.
- [X] The PR text includes a **detailed explanation** (more than 50 chars)
- [ ] I have thoroughly tested my contribution.

Adds a better warning when no more free user slot is available and also puts this warning before the user enters any new pin.

This was tested by foring the function to trigger. I did not fill up 16 users again as this takes forever with a single smartcard (the rest is in the other appartment). The gui works as expected, but it should be tested that the return type triggers correct.

The new bundle was not tested, as I've not yet "recompiled" a bundle. As far as I can see those changes should work, however the added string should be verified to work.

Edit: The message displaying was now tested manually. Only left to test if the text appears when all users are filled up and also disappears if you free up one user again. This will follow in a week.
