### PR TITLE
MP Mini Input recognized too early

### DIFF
--- a/source_code/src/UTILS/delays.c
+++ b/source_code/src/UTILS/delays.c
@@ -23,6 +23,7 @@
 *    Author:   Mathieu Stephan
 */ 
 #include "timer_manager.h"
+#include "mini_inputs.h"
 
 /*! \fn     userViewDelay(void)
 *   \brief  2secs delay for the user to view information
@@ -30,6 +31,11 @@
 void userViewDelay(void)
 {
     timerBasedDelayMs(2000);
+
+#ifdef MINI_VERSION
+    // Discard user wheel input
+    miniWheelClearDetections();
+#endif
 }
 
 /*! \fn     smallForLoopBasedDelay(void)


### PR DESCRIPTION
Fixes #259
- [X] This PR is compliant with the contributing guidelines (if not, please describe why): code is fully documented and if possible a .md file is made.
- [X] The PR text includes a **detailed explanation** (more than 50 chars)
- [X] I have thoroughly tested my contribution.

After a 2 second delay the user input are cleared on the mini. This prevents the next menu to scroll if the user scrolls while the screen is active.

The bug was fixed inside the delay function as the delay is especially used for information menus at several places. The best place was in the delay function itself as a 2 second delay is always used for such information where you want to discard the user input. The additional flash usage is 2 more bytes.

This was tested when unlocking the smartcard, when no favorites are available and when you change the smartcard pin.
