### PR TITLE
Avoid quick "using moolticute" message.

### DIFF
--- a/chrome_app/vendor/mooltipass/device.js
+++ b/chrome_app/vendor/mooltipass/device.js
@@ -223,7 +223,9 @@ mooltipass.device.checkForMoolticute = function() {
  * triggered by mooltipass.app.init()
  */
 mooltipass.device.init = function() {
-    mooltipass.device.usingMoolticute = true;
+    mooltipass.device.usingMoolticute = false;
+    mooltipass.device._forceEndMemoryManagementModeLock = false;
+    mooltipass.device.restartProcessingQueue();
     this.checkForMoolticute();
     // only init if moolticute isn't running.
     // var moolticuteSocket = new WebSocket('ws://127.0.0.1:30035');


### PR DESCRIPTION
Quick PR. works. Will be cleaning up and improving later.

Two major changes: 

1 - no more reconnecting web socket (we use our own version, tries to connect from 300ms to 3000ms)

2 - Added a few extra MS for reconnecting web socket. 

In high end computers, cpu usage stays at 1.5%