### PR TITLE
Change val() usage for "send keys" in the password generator

### DIFF
--- a/chrome_extension/mooltipass-content.js
+++ b/chrome_extension/mooltipass-content.js
@@ -157,7 +157,8 @@ cipPassword.createDialog = function(inputs, $pwField) {
 
 	mpJQ("#mooltipass-use-as-password").click(function(e){
 		var password = mpJQ("#mooltipass-password-generator").val();
-		mpJQ("input[type='password']:not('.mooltipass-password-do-not-update')").val(password);
+
+		mpJQ("input[type='password']:not('.mooltipass-password-do-not-update')").sendkeys( password ).dispatchEvent(new Event('change'));
 		e.preventDefault();
 	});
 


### PR DESCRIPTION
Changed the val() usage in the password generator for sendkeys method. This method has proven effective and shouldn't affect the behavior at all. I also added a change event to be dispatched after the sendkeys command (as that's usually used by scripts to check that something has changed)