### PR TITLE
Fix blinking icon / Fix reconnection when closing moolticute

### DIFF
--- a/chrome_app/vendor/mooltipass/device.js
+++ b/chrome_app/vendor/mooltipass/device.js
@@ -210,11 +210,13 @@ mooltipass.device.checkForMoolticute = function() {
 
     this.moolticuteSocket.onclose = function() {
         if ( mooltipass.device.usingMoolticute == true ) {
-            mooltipass.device._forceEndMemoryManagementModeLock = false;
-        
-            // Initial start processing queue
-            mooltipass.device.restartProcessingQueue();
+            mooltipass.device.usingMoolticute = false;
         }
+        //     mooltipass.device._forceEndMemoryManagementModeLock = false;
+        
+        //     // Initial start processing queue
+        //     mooltipass.device.restartProcessingQueue();
+        // }
 
         clearInterval( mooltipass.device.interval );
         mooltipass.device.interval = setInterval(mooltipass.device.checkStatus, 350);
@@ -231,6 +233,7 @@ mooltipass.device.init = function() {
     mooltipass.device.usingMoolticute = false;
     mooltipass.device._forceEndMemoryManagementModeLock = false;
     mooltipass.device.restartProcessingQueue();
+    mooltipass.device.interval = setInterval(mooltipass.device.checkStatus, 350);
     this.checkForMoolticute();
 };
 
@@ -738,6 +741,9 @@ mooltipass.device.onDataReceived = function(reportId, data) {
     var cmd = bytes[1];
 
     var command = mooltipass.device.commandsReverse[cmd];
+
+    // Stop processing if we get an unknown command
+    if ( typeof command == undefined) return;
 
     if(mooltipass.device.debug)
     {

--- a/chrome_extension/vendor/mooltipass/backend.js
+++ b/chrome_extension/vendor/mooltipass/backend.js
@@ -56,7 +56,8 @@ mooltipass.backend.setStatusIcon = function(icon_name) {
 }
 
 mooltipass.backend.updateStatusIcon = function() {
-    if (mooltipass.device.getStatus()['deviceUnlocked']) {
+    var status = mooltipass.device.getStatus();
+    if (status['deviceUnlocked']) {
         iconName = "normal";
     } else {
         iconName = "cross";

--- a/chrome_extension/vendor/mooltipass/moolticute.js
+++ b/chrome_extension/vendor/mooltipass/moolticute.js
@@ -152,13 +152,16 @@ moolticute.fireEvent = function(type, data) {
 
 moolticute.on('statusChange', function(type, data) {
     if (background_debug_msg > 4) mpDebug.log('%c Moolticute statusChange event received', mpDebug.css('FFC6A0'));
-    mooltipass.device._status = {
-        'connected': moolticute.status.connected,
-        'unlocked': moolticute.status.unlocked,
-        'version': moolticute.status.version,
-        'state' : moolticute.status.state
-    };
-    mooltipass.connectedToApp = moolticute.connectedToDaemon;
+    if ( moolticute.connectedToDaemon ) {
+        mooltipass.device._status = {
+            'connected': moolticute.status.connected,
+            'unlocked': moolticute.status.unlocked,
+            'version': moolticute.status.version,
+            'state' : moolticute.status.state
+        };    
+    }
+    
+    mooltipass.connectedToApp = !moolticute.connectedToDaemon;
 });
 
 // Encapsulation for websocket


### PR DESCRIPTION
Device.js: 

1. Set usingMoolticute to false for obvious reasons
2. Start checking status by default (then stops when moolticute opens)
3. Avoid console output of commands meant for moolticute

Backend.js:

1. Small change in order to be able to track/debug status changes

Moolticute:

1. Just change status when we're using moolticute. Leave status to standard method when using the APP



