### PR TITLE
Add script option to generate bundle upload password

### DIFF
--- a/tools/_python_framework/mooltipass_tool.py
+++ b/tools/_python_framework/mooltipass_tool.py
@@ -35,6 +35,7 @@
 #                                                                                                                               #
 #################################################################################################################################
 from mooltipass_mass_prod_init_proc import *
+from mooltipass_security_check import *
 from mooltipass_hid_device import *
 from mooltipass_init_proc import *
 from generate_prog_file import *
@@ -212,6 +213,30 @@ def main():
 			else:
 				print "set_card_password: not enough args!"
 		
+		if sys.argv[1] == "get_upload_password":
+			if len(sys.argv) > 3:
+				AESKey2 = sys.argv[3]
+				UIDReqKey = sys.argv[2]
+				
+				# Check Key sizes
+				if len(AESKey2) != AES_KEY_SIZE*2:
+					print "Wrong AES Key 2 size"
+					return
+				if len(UIDReqKey) != UID_REQUEST_KEY_SIZE*2:
+					print "Wrong UID request key size"
+					return
+				
+				# Convert string into arrays
+				AESKey2_array = array('B', AESKey2.decode("hex"))
+				
+				uid = mooltipass_device.getUID(UIDReqKey)
+				if uid != None:
+					print "Device UID (make sure it's correct):", "".join(format(x, "02x") for x in uid)
+					text_password = generateBundlePasswordUpload(version_data[1], uid, AESKey2_array)
+					print "Your upload password is:",text_password
+			else:
+				print "get_upload_password: not enough args!"
+				print "get_upload_password <UID Request Key> <AES Key 2>"
 		
 	#mooltipass_device.sendCustomPacket()
 	#mooltipass_device.checkSecuritySettings()

--- a/tools/_python_framework/mooltipass_tool.py
+++ b/tools/_python_framework/mooltipass_tool.py
@@ -169,7 +169,7 @@ def main():
 				if uid != None:
 					print "UID:", "".join(format(x, "02x") for x in uid)
 			else:
-				print "decrypt_mini_prod: not enough args!"
+				print "get_uid: not enough args!"
 				
 		if sys.argv[1] == "read_user_db_change_nb":
 			mooltipass_device.getMooltipassUserDbChangeNumber()		

--- a/tools/_python_framework/signing_and_uploading_your_own_firmware.txt
+++ b/tools/_python_framework/signing_and_uploading_your_own_firmware.txt
@@ -17,5 +17,6 @@ d) generating and uploading your bundle
 - approve the prompt on the device, DO NOT DISCONNECT THE MOOLTIPASS WHEN THE SCREEN IS OFF. Wait 5 minutes.
 
 II) Required informations
-a) AES key 1: will be sent to you in person through a secured and authenticated communication channel. The Mooltipass Team declines all responsibility for loss of data or damaged unit once this key is sent to the customer.
+a) AES key 1, AES key 2 and UID request key: will be sent to you in person through a secured and authenticated communication channel. The Mooltipass Team declines all responsibility for loss of data or damaged unit once this key is sent to the customer.
 b) Uploading Password: the password is current_firmware_version (as a string, for example "v1.2") concatenated with the device UID key (which is 6 bytes long). This string is then encrypted using the device AES key 2. For example on how to generate the uploading password, please check out generateBundlePasswordUpload() in mooltipass_security_check.py . For information, this password is just meant as a way to protect against DoS.
+   The uploading password can be generated with the following command with the MPM plugged: python mooltipass_tool.py get_upload_password <your_uid_request_key> <your_aes_key2>


### PR DESCRIPTION
- [x] This PR is compliant with the contributing guidelines (if not, please describe why): code is fully documented and if possible a .md file is made.
- [x] The PR text includes a **detailed explanation** (more than 50 chars)
- [x] I have thoroughly tested my contribution.

Added a script option to generate the necessary bundle upload password needed to upgrade you MPM with an official or custom firmware.
Requires a plugged MPM, AES Key 2 and UID Request Key.

Although the key could be generated "offline", it's safer to require plugging the MPM to automatically retrieve the current firmware version and UID.