### PR TITLE
Fix bug on 2nd request after a cancel

### DIFF
--- a/chrome_extension/vendor/mooltipass/moolticute.js
+++ b/chrome_extension/vendor/mooltipass/moolticute.js
@@ -272,13 +272,15 @@ moolticute.websocket = {
     messageTranslator: function( msg ) {
         var output = { data: {} };
         if ( msg.command && msg.command == 'getCredentials' ) {
-            output.msg = 'ask_password',
-            output.data.failed = msg.success?false:true,
-            output.data.login = msg.credentials.login,
-            output.data.password = msg.credentials.password
+            output.msg = 'ask_password';
+            output.data.failed = msg.success?false:true;
+            if ( msg.success ) {
+                output.data.login = msg.credentials.login;
+                output.data.password = msg.credentials.password;    
+            }
         } else if ( msg.command && msg.command == 'getRandomNumber') {
-            output.msg = 'get_random_numbers',
-            output.data = msg.random
+            output.msg = 'get_random_numbers';
+            output.data = msg.random;
         } else if ( msg.command && msg.command == 'getMooltipassStatus') {
             output.msg = 'status_changed';
             if ( msg.value == 'unlocked' ) output.data = 'Unlocked';


### PR DESCRIPTION
Fixes: 

Open a tab with a prompt request, then close it without approving nothing
Then open again a new tab
You will not get the prompt on the device