### PR TITLE
Feature: Button at boot and hardening

### DIFF
--- a/source_code/src/GUI/mini_gui_smartcard_functions.c
+++ b/source_code/src/GUI/mini_gui_smartcard_functions.c
@@ -59,8 +59,8 @@ RET_TYPE guiDisplayInsertSmartCardScreenAndWait(void)
     #define BETA_TESTER_V
     #ifdef BETA_TESTER_V
         miniOledBitmapDrawFlash(0, 0, BITMAP_INSERT_CARD, OLED_SCROLL_NONE);
-        #ifdef MINI_CREDENTIAL_MANAGEMENT
-        miniOledPutCenteredString(21, "alt-beta v0.60");
+        #ifdef MINI_HARDENED_FW
+        miniOledPutCenteredString(21, "hardened 1.00");
         #endif
         miniOledFlushEntireBufferToDisplay();
     #else

--- a/source_code/src/defines.h
+++ b/source_code/src/defines.h
@@ -329,6 +329,9 @@
 // Uncomment to globally enable all cleanup & hardening features
 //#define MINI_HARDENED_FW
 
+// Uncomment to allow detection of button press at boot-time
+//#define MINI_BUTTON_AT_BOOT
+
 // set all hardening and cleanup features at once
 #if defined(MINI_VERSION) && defined(MINI_HARDENED_FW)
     /* features from stock firmware */
@@ -336,6 +339,9 @@
     #define DISABLE_SINGLE_CREDENTIAL_ON_CARD_STORAGE
     #define DISABLE_FUNCTIONAL_TEST
     #define SKIP_TUTORIAL
+
+    /* specific cleanup & hardening features */
+    #define MINI_BUTTON_AT_BOOT
 #endif
 
 /**************** HW MACROS ****************/

--- a/source_code/src/defines.h
+++ b/source_code/src/defines.h
@@ -196,6 +196,7 @@
     #define MINI_PREPROD_KICKSTARTER_SETUP
     #define ENABLE_CREDENTIAL_MANAGEMENT                    // WARNING: requires a new resource bundle.img with additional strings
     #define REPLACE_FAVORITES_WITH_CREDENTIAL_MANAGEMENT    // replaces favorites selection menu with creds management menu
+    #define MINI_HARDENED_FW
 #elif defined(MINI_KICKSTARTER_SETUP)
     #define MINI_VERSION
     #define FLASH_CHIP_8M
@@ -215,6 +216,7 @@
     #define MINI_PREPROD_KICKSTARTER_SETUP
     #define ENABLE_CREDENTIAL_MANAGEMENT                    // WARNING: requires a new resource bundle.img with additional strings
     #define REPLACE_FAVORITES_WITH_CREDENTIAL_MANAGEMENT    // replaces favorites selection menu with creds management menu
+    #define MINI_HARDENED_FW
 #endif
 
 /* Features depending on the mooltipass version */
@@ -320,6 +322,21 @@
 /************** MOOLTIPASS DEMOS ***************/
 // Uncomment to set screen saver as default image
 //#define MINI_DEMO_VIDEO
+
+/************** FIRMWARE HARDENING ***************/
+// Various hardening-related features
+
+// Uncomment to globally enable all cleanup & hardening features
+//#define MINI_HARDENED_FW
+
+// set all hardening and cleanup features at once
+#if defined(MINI_VERSION) && defined(MINI_HARDENED_FW)
+    /* features from stock firmware */
+    #define NO_ACCELEROMETER_FUNCTIONALITIES
+    #define DISABLE_SINGLE_CREDENTIAL_ON_CARD_STORAGE
+    #define DISABLE_FUNCTIONAL_TEST
+    #define SKIP_TUTORIAL
+#endif
 
 /**************** HW MACROS ****************/
 #define CPU_PRESCALE(n)         (CLKPR = 0x80, CLKPR = (n))

--- a/source_code/src/defines.h
+++ b/source_code/src/defines.h
@@ -73,7 +73,8 @@
  *  MINI_KICKSTARTER_SETUP
  *  => mooltipass mini production kickstarter version (8Mb)
 */
-#define MINI_PREPRODUCTION_SETUP_ACC
+#define MINI_PREPROD_KICKSTARTER_SETUP_HARDENED_CREDENTIAL_MANAGEMENT
+//#define MINI_PREPRODUCTION_SETUP_ACC
 //#define POST_KICKSTARTER_UPDATE_SETUP
 
 #if defined(BETATESTERS_SETUP)
@@ -183,6 +184,18 @@
     #define HARDWARE_MINI_CLICK_V2
     #define DISABLE_USB_SET_UID_DEV_PASSWORD_COMMANDS
     #define KNOCK_SETTINGS_CHANGE_PREVENT_WHEN_CARD_INSERTED
+#elif defined(MINI_PREPROD_KICKSTARTER_SETUP_HARDENED_CREDENTIAL_MANAGEMENT)
+    //#define STACK_DEBUG
+    #define MINI_VERSION
+    #define FLASH_CHIP_4M
+    //#define DATA_STORAGE_EN
+    #define HARDWARE_MINI_CLICK_V2
+    #define DISABLE_USB_SET_UID_DEV_PASSWORD_COMMANDS
+    #define KNOCK_SETTINGS_CHANGE_PREVENT_WHEN_CARD_INSERTED
+
+    #define MINI_PREPROD_KICKSTARTER_SETUP
+    #define ENABLE_CREDENTIAL_MANAGEMENT                    // WARNING: requires a new resource bundle.img with additional strings
+    #define REPLACE_FAVORITES_WITH_CREDENTIAL_MANAGEMENT    // replaces favorites selection menu with creds management menu
 #elif defined(MINI_KICKSTARTER_SETUP)
     #define MINI_VERSION
     #define FLASH_CHIP_8M
@@ -190,6 +203,18 @@
     #define HARDWARE_MINI_CLICK_V2
     #define DISABLE_USB_SET_UID_DEV_PASSWORD_COMMANDS
     #define KNOCK_SETTINGS_CHANGE_PREVENT_WHEN_CARD_INSERTED
+#elif defined(MINI_KICKSTARTER_SETUP_HARDENED_CREDENTIAL_MANAGEMENT)
+    //#define STACK_DEBUG
+    #define MINI_VERSION
+    #define FLASH_CHIP_8M
+    //#define DATA_STORAGE_EN
+    #define HARDWARE_MINI_CLICK_V2
+    #define DISABLE_USB_SET_UID_DEV_PASSWORD_COMMANDS
+    #define KNOCK_SETTINGS_CHANGE_PREVENT_WHEN_CARD_INSERTED
+
+    #define MINI_PREPROD_KICKSTARTER_SETUP
+    #define ENABLE_CREDENTIAL_MANAGEMENT                    // WARNING: requires a new resource bundle.img with additional strings
+    #define REPLACE_FAVORITES_WITH_CREDENTIAL_MANAGEMENT    // replaces favorites selection menu with creds management menu
 #endif
 
 /* Features depending on the mooltipass version */

--- a/source_code/src/mooltipass.c
+++ b/source_code/src/mooltipass.c
@@ -89,6 +89,10 @@ uint8_t mp_timeout_enabled = FALSE;
 /* Flag set by anything to signal activity */
 uint8_t act_detected_flag = FALSE;
 
+/* On the MINI, flag set by pressing the wheel at boot-time */
+#if defined(MINI_VERSION) && defined(MINI_BUTTON_AT_BOOT)
+uint8_t mini_button_at_boot = FALSE;
+#endif
 
 /*! \fn     reboot_platform(void)
 *   \brief  Function to reboot the MCU using the WDT
@@ -218,6 +222,19 @@ int main(void)
         {
             start_bootloader();
         }
+    #endif
+
+    /********************************************************************/
+    /**           ENABLE BOOT-TIME BUTTON PRESS DETECTION              **/
+    /*                                                                  */
+    /* On mini units, a button pressed at boot enables additional       */
+    /* features or hardening                                            */
+    /********************************************************************/
+    #if defined(MINI_VERSION) && defined(MINI_BUTTON_AT_BOOT)
+    if(electricalJumpToBootloaderCondition() == TRUE)
+    {
+        mini_button_at_boot = TRUE;
+    }
     #endif
 
     /** HARDWARE INITIALIZATION **/

--- a/source_code/src/mooltipass.c
+++ b/source_code/src/mooltipass.c
@@ -113,7 +113,7 @@ int main(void)
     #if defined(HARDWARE_OLIVIER_V1)                                                        // Only the Mooltipass standard version has a touch panel
         RET_TYPE touch_init_result;                                                         // Touch initialization result
     #endif                                                                                  //
-    #if defined(MINI_VERSION)                                                               // Dedicated to Mooltipass mini
+    #if defined(MINI_VERSION) && !defined(DISABLE_FUNCTIONAL_TEST) // Dedicated to Mooltipass mini
         RET_TYPE mini_inputs_result;                                                        // Mooltipass mini input initialization result
     #endif                                                                                  //
     RET_TYPE flash_init_result;                                                             // Flash initialization result
@@ -240,7 +240,11 @@ int main(void)
     initFlashIOs();                             // Initialize Flash inputs/outputs
     spiUsartBegin();                            // Start USART SPI at 8MHz (standard) or 4MHz (mini)
     #if defined(MINI_VERSION)                   // For the Mooltipass Mini inputs
-        mini_inputs_result = initMiniInputs();  // Initialize Mini Inputs
+        #if !defined(DISABLE_FUNCTIONAL_TEST) // mini_input_result is not used if functional test is disabled, triggering -Werror=unused-but-set-variable at compilation
+            mini_inputs_result = initMiniInputs();  // Initialize Mini Inputs
+        #else
+            initMiniInputs();  // Initialize Mini Inputs
+        #endif
     #endif                                      //
 
     /* If offline mode isn't enabled, wait for device to be enumerated */
@@ -314,7 +318,11 @@ int main(void)
     #elif defined(MINI_VERSION)
         #if defined(MINI_CLICK_BETATESTERS_SETUP) || defined(MINI_AVRISP_PROG_TEST_SETUP)
             (void)fuse_ok;
-            while ((flash_init_result != RETURN_OK) || (mini_inputs_result != RETURN_OK));
+            #if !defined(DISABLE_FUNCTIONAL_TEST) // to accomodate -Werror=unused-but-set-variable
+                while ((flash_init_result != RETURN_OK) || (mini_inputs_result != RETURN_OK));
+            #else
+                while (flash_init_result != RETURN_OK);
+            #endif
         #elif (defined(MINI_PREPRODUCTION_SETUP_ACC) || defined(MINI_PREPROD_KICKSTARTER_SETUP) || defined(MINI_KICKSTARTER_SETUP))
             /* We do not hang if accelerometer is not present as it isn't crucial, moreover we already tested it in the functional test */
             while ((flash_init_result != RETURN_OK) || (fuse_ok != TRUE));

--- a/source_code/src/mooltipass.h
+++ b/source_code/src/mooltipass.h
@@ -39,6 +39,10 @@ extern uint8_t mp_lock_unlock_shortcuts;
 extern uint8_t mp_timeout_enabled;
 extern uint8_t act_detected_flag;
 
+#if defined(MINI_VERSION) && defined(MINI_BUTTON_AT_BOOT)
+uint8_t mini_button_at_boot;
+#endif
+
 /* Function prototypes */
 void reboot_platform(void);
 


### PR DESCRIPTION
- [x] This PR is compliant with the contributing guidelines (if not, please describe why): code is fully documented and if possible a .md file is made.
- [x] The PR text includes a **detailed explanation** (more than 50 chars)
- [x] I have thoroughly tested my contribution.

New feature allowing to boot the mini with the wheel pressed and set a flag accordingly. 

- Adds define layout and meta-defines for hardening purposes.
- Also adds defines for pre-production and ks models (4Mb/8Mb flash).
- Finally, adds a custom version string to visually identify devices with a different firmware from stock devices.