### PR TITLE
Hardening: disable "silent" password check over USB

### DIFF
--- a/source_code/src/USB/usb_cmd_parser.c
+++ b/source_code/src/USB/usb_cmd_parser.c
@@ -210,8 +210,10 @@ void usbProcessIncoming(uint8_t caller_id)
     uint8_t datacmd = msg->cmd;
 
 #ifdef USB_FEATURE_PLUGIN_COMMS
+    #ifndef DISABLE_USB_CMD_CHECK_PASSWORD
     // Temp ret_type
     RET_TYPE temp_rettype;
+    #endif
 #endif
 
     // Debug comms
@@ -257,7 +259,11 @@ void usbProcessIncoming(uint8_t caller_id)
     {
         max_text_size = NODE_CHILD_SIZE_OF_LOGIN;
     }
+#ifndef DISABLE_USB_CMD_CHECK_PASSWORD
     else if ((datacmd == CMD_SET_PASSWORD) || (datacmd == CMD_CHECK_PASSWORD))
+#else
+    else if (datacmd == CMD_SET_PASSWORD)
+#endif
     {
         max_text_size = NODE_CHILD_SIZE_OF_PASSWORD;
     }
@@ -480,6 +486,7 @@ void usbProcessIncoming(uint8_t caller_id)
         }
 
         // check password
+        #ifndef DISABLE_USB_CMD_CHECK_PASSWORD
         case CMD_CHECK_PASSWORD :
         {
             temp_rettype = checkPasswordForContext(msg->body.data);
@@ -497,6 +504,7 @@ void usbProcessIncoming(uint8_t caller_id)
             }
             break;
         }
+        #endif
 
         // Add credential context
         case CMD_ADD_CONTEXT :

--- a/source_code/src/defines.h
+++ b/source_code/src/defines.h
@@ -335,6 +335,9 @@
 // Uncomment to disable screensaver
 //#define DISABLE_SCREENSAVER
 
+// Uncomment to disable password compare over USB
+// #define DISABLE_USB_CMD_CHECK_PASSWORD
+
 // set all hardening and cleanup features at once
 #if defined(MINI_VERSION) && defined(MINI_HARDENED_FW)
     /* features from stock firmware */
@@ -346,6 +349,9 @@
     /* specific cleanup & hardening features */
     #define MINI_BUTTON_AT_BOOT
     #define DISABLE_SCREENSAVER
+
+    /* USB command support hardening */
+    #define DISABLE_USB_CMD_CHECK_PASSWORD      // saves about 152 bytes
 #endif
 
 /**************** HW MACROS ****************/


### PR DESCRIPTION
- [x] This PR is compliant with the contributing guidelines (if not, please describe why): code is fully documented and if possible a .md file is made.
- [x] The PR text includes a **detailed explanation** (more than 50 chars)
- [x] I have thoroughly tested my contribution.

This PR adds a define to optionally remove CMD_CHECK_PASSWORD which allows silent password checking over USB against the database.