### PR TITLE
Hardening: Restrict memory management mode

### DIFF
--- a/source_code/src/USB/usb_cmd_parser.c
+++ b/source_code/src/USB/usb_cmd_parser.c
@@ -68,6 +68,10 @@ extern uint8_t __stack;
 /* External var, end of known static RAM (to be filled by linker) */
 extern uint8_t _end;
 
+#if defined(MINI_VERSION) && defined(MINI_BUTTON_AT_BOOT)
+extern uint8_t mini_button_at_boot;
+#endif
+
 /*! \fn     checkMooltipassPassword(uint8_t* data)
 *   \brief  Check that the provided bytes is the mooltipass password
 *   \param  data            Password to be checked
@@ -617,6 +621,14 @@ void usbProcessIncoming(uint8_t caller_id)
         // Read user profile in flash
         case CMD_START_MEMORYMGMT :
         {            
+            #if defined(MINI_VERSION) && defined(MINI_BUTTON_AT_BOOT) && defined(MINI_RESTRICT_MEMORYMGMT)
+            // Only allow memory management if the device was specifically booted with the wheel pressed
+            if(mini_button_at_boot == FALSE)
+            {
+                plugin_return_value = PLUGIN_BYTE_ERROR;
+                break;
+            }
+            #endif
             // Check that the smartcard is unlocked
             if (getSmartCardInsertedUnlocked() == TRUE)
             {

--- a/source_code/src/USB/usb_cmd_parser.c
+++ b/source_code/src/USB/usb_cmd_parser.c
@@ -68,10 +68,6 @@ extern uint8_t __stack;
 /* External var, end of known static RAM (to be filled by linker) */
 extern uint8_t _end;
 
-#if defined(MINI_VERSION) && defined(MINI_BUTTON_AT_BOOT)
-extern uint8_t mini_button_at_boot;
-#endif
-
 /*! \fn     checkMooltipassPassword(uint8_t* data)
 *   \brief  Check that the provided bytes is the mooltipass password
 *   \param  data            Password to be checked

--- a/source_code/src/USB/usb_cmd_parser.c
+++ b/source_code/src/USB/usb_cmd_parser.c
@@ -210,8 +210,10 @@ void usbProcessIncoming(uint8_t caller_id)
     uint8_t datacmd = msg->cmd;
 
 #ifdef USB_FEATURE_PLUGIN_COMMS
+    #ifndef DISABLE_USB_CMD_CHECK_PASSWORD
     // Temp ret_type
     RET_TYPE temp_rettype;
+    #endif
 #endif
 
     // Debug comms
@@ -257,7 +259,11 @@ void usbProcessIncoming(uint8_t caller_id)
     {
         max_text_size = NODE_CHILD_SIZE_OF_LOGIN;
     }
+#ifndef DISABLE_USB_CMD_CHECK_PASSWORD
     else if ((datacmd == CMD_SET_PASSWORD) || (datacmd == CMD_CHECK_PASSWORD))
+#else
+    else if (datacmd == CMD_SET_PASSWORD)
+#endif
     {
         max_text_size = NODE_CHILD_SIZE_OF_PASSWORD;
     }
@@ -480,6 +486,7 @@ void usbProcessIncoming(uint8_t caller_id)
         }
 
         // check password
+        #ifndef DISABLE_USB_CMD_CHECK_PASSWORD
         case CMD_CHECK_PASSWORD :
         {
             temp_rettype = checkPasswordForContext(msg->body.data);
@@ -497,6 +504,7 @@ void usbProcessIncoming(uint8_t caller_id)
             }
             break;
         }
+        #endif
 
         // Add credential context
         case CMD_ADD_CONTEXT :

--- a/source_code/src/defines.h
+++ b/source_code/src/defines.h
@@ -335,6 +335,9 @@
 // Uncomment to disable screensaver
 //#define DISABLE_SCREENSAVER
 
+// Uncomment to disable password compare over USB
+// #define DISABLE_USB_CMD_CHECK_PASSWORD
+
 // set all hardening and cleanup features at once
 #if defined(MINI_VERSION) && defined(MINI_HARDENED_FW)
     /* features from stock firmware */
@@ -346,6 +349,9 @@
     /* specific cleanup & hardening features */
     #define MINI_BUTTON_AT_BOOT
     #define DISABLE_SCREENSAVER
+
+    /* USB command support hardening */
+    #define DISABLE_USB_CMD_CHECK_PASSWORD      // saves about 152 bytes
 #endif
 
 /**************** HW MACROS ****************/

--- a/source_code/src/defines.h
+++ b/source_code/src/defines.h
@@ -338,6 +338,10 @@
 // Uncomment to disable password compare over USB
 // #define DISABLE_USB_CMD_CHECK_PASSWORD
 
+// Uncomment to restrict memory management mode to a device booted 
+// with the wheel pressed
+// #define MINI_RESTRICT_MEMORYMGMT // Requires MINI_BUTTON_AT_BOOT
+
 // set all hardening and cleanup features at once
 #if defined(MINI_VERSION) && defined(MINI_HARDENED_FW)
     /* features from stock firmware */
@@ -352,6 +356,14 @@
 
     /* USB command support hardening */
     #define DISABLE_USB_CMD_CHECK_PASSWORD      // saves about 152 bytes
+
+    /* USB command restriction to boot with wheel pressed */
+    #define MINI_RESTRICT_MEMORYMGMT
+#endif
+
+// enforce feature requirements
+#if defined(MINI_RESTRICT_MEMORYMGMT)
+    #define MINI_BUTTON_AT_BOOT
 #endif
 
 /**************** HW MACROS ****************/

--- a/source_code/src/mooltipass.h
+++ b/source_code/src/mooltipass.h
@@ -40,7 +40,7 @@ extern uint8_t mp_timeout_enabled;
 extern uint8_t act_detected_flag;
 
 #if defined(MINI_VERSION) && defined(MINI_BUTTON_AT_BOOT)
-uint8_t mini_button_at_boot;
+extern uint8_t mini_button_at_boot;
 #endif
 
 /* Function prototypes */


### PR DESCRIPTION
- [x] This PR is compliant with the contributing guidelines (if not, please describe why): code is fully documented and if possible a .md file is made.
- [x] The PR text includes a **detailed explanation** (more than 50 chars)
- [x] I have thoroughly tested my contribution.

Adds an optional restriction to memory management mode, only allowing the transition if the device has been booted with the wheel pressed.
Also fixes flag variable export.