### PR TITLE
Hardening: Disable usb cmd rng

### DIFF
--- a/source_code/src/USB/usb_cmd_parser.c
+++ b/source_code/src/USB/usb_cmd_parser.c
@@ -68,6 +68,10 @@ extern uint8_t __stack;
 /* External var, end of known static RAM (to be filled by linker) */
 extern uint8_t _end;
 
+#if defined(MINI_VERSION) && defined(MINI_BUTTON_AT_BOOT)
+extern uint8_t mini_button_at_boot;
+#endif
+
 /*! \fn     checkMooltipassPassword(uint8_t* data)
 *   \brief  Check that the provided bytes is the mooltipass password
 *   \param  data            Password to be checked
@@ -617,6 +621,14 @@ void usbProcessIncoming(uint8_t caller_id)
         // Read user profile in flash
         case CMD_START_MEMORYMGMT :
         {            
+            #if defined(MINI_VERSION) && defined(MINI_BUTTON_AT_BOOT) && defined(MINI_RESTRICT_MEMORYMGMT)
+            // Only allow memory management if the device was specifically booted with the wheel pressed
+            if(mini_button_at_boot == FALSE)
+            {
+                plugin_return_value = PLUGIN_BYTE_ERROR;
+                break;
+            }
+            #endif
             // Check that the smartcard is unlocked
             if (getSmartCardInsertedUnlocked() == TRUE)
             {

--- a/source_code/src/USB/usb_cmd_parser.c
+++ b/source_code/src/USB/usb_cmd_parser.c
@@ -68,10 +68,6 @@ extern uint8_t __stack;
 /* External var, end of known static RAM (to be filled by linker) */
 extern uint8_t _end;
 
-#if defined(MINI_VERSION) && defined(MINI_BUTTON_AT_BOOT)
-extern uint8_t mini_button_at_boot;
-#endif
-
 /*! \fn     checkMooltipassPassword(uint8_t* data)
 *   \brief  Check that the provided bytes is the mooltipass password
 *   \param  data            Password to be checked

--- a/source_code/src/USB/usb_cmd_parser.c
+++ b/source_code/src/USB/usb_cmd_parser.c
@@ -1414,6 +1414,7 @@ void usbProcessIncoming(uint8_t caller_id)
         #endif
         
         // Get 32 random bytes
+        #ifndef DISABLE_USB_CMD_GET_RANDOM_NUMBER
         case CMD_GET_RANDOM_NUMBER :
         {
             uint8_t randomBytes[32];
@@ -1421,6 +1422,7 @@ void usbProcessIncoming(uint8_t caller_id)
             usbSendMessage(CMD_GET_RANDOM_NUMBER, 32, randomBytes);
             return;
         }  
+        #endif
         
         // Set current date
         case CMD_SET_DATE :

--- a/source_code/src/defines.h
+++ b/source_code/src/defines.h
@@ -338,6 +338,9 @@
 // Uncomment to disable password compare over USB
 // #define DISABLE_USB_CMD_CHECK_PASSWORD
 
+// Uncomment to disable RNG over USB
+// #define DISABLE_USB_CMD_GET_RANDOM_NUMBER
+
 // Uncomment to restrict memory management mode to a device booted 
 // with the wheel pressed
 // #define MINI_RESTRICT_MEMORYMGMT // Requires MINI_BUTTON_AT_BOOT
@@ -356,6 +359,7 @@
 
     /* USB command support hardening */
     #define DISABLE_USB_CMD_CHECK_PASSWORD      // saves about 152 bytes
+    #define DISABLE_USB_CMD_GET_RANDOM_NUMBER   // saves about 20 bytes
 
     /* USB command restriction to boot with wheel pressed */
     #define MINI_RESTRICT_MEMORYMGMT

--- a/source_code/src/defines.h
+++ b/source_code/src/defines.h
@@ -348,21 +348,21 @@
 // set all hardening and cleanup features at once
 #if defined(MINI_VERSION) && defined(MINI_HARDENED_FW)
     /* features from stock firmware */
-    #define NO_ACCELEROMETER_FUNCTIONALITIES
-    #define DISABLE_SINGLE_CREDENTIAL_ON_CARD_STORAGE
-    #define DISABLE_FUNCTIONAL_TEST
-    #define SKIP_TUTORIAL
+    #define NO_ACCELEROMETER_FUNCTIONALITIES          // saves about 782 bytes
+    #define DISABLE_SINGLE_CREDENTIAL_ON_CARD_STORAGE // saves about 168 bytes
+    #define DISABLE_FUNCTIONAL_TEST                   // saves about 466 bytes
+    #define SKIP_TUTORIAL                             // saves about 62 bytes
 
     /* specific cleanup & hardening features */
-    #define MINI_BUTTON_AT_BOOT
-    #define DISABLE_SCREENSAVER
+    #define MINI_BUTTON_AT_BOOT                 // uses about 40 bytes
+    #define DISABLE_SCREENSAVER                 // saves about 368 bytes
 
     /* USB command support hardening */
     #define DISABLE_USB_CMD_CHECK_PASSWORD      // saves about 152 bytes
     #define DISABLE_USB_CMD_GET_RANDOM_NUMBER   // saves about 20 bytes
 
     /* USB command restriction to boot with wheel pressed */
-    #define MINI_RESTRICT_MEMORYMGMT
+    #define MINI_RESTRICT_MEMORYMGMT            // uses about 10 bytes
 #endif
 
 // enforce feature requirements

--- a/source_code/src/defines.h
+++ b/source_code/src/defines.h
@@ -338,6 +338,10 @@
 // Uncomment to disable password compare over USB
 // #define DISABLE_USB_CMD_CHECK_PASSWORD
 
+// Uncomment to restrict memory management mode to a device booted 
+// with the wheel pressed
+// #define MINI_RESTRICT_MEMORYMGMT // Requires MINI_BUTTON_AT_BOOT
+
 // set all hardening and cleanup features at once
 #if defined(MINI_VERSION) && defined(MINI_HARDENED_FW)
     /* features from stock firmware */
@@ -352,6 +356,14 @@
 
     /* USB command support hardening */
     #define DISABLE_USB_CMD_CHECK_PASSWORD      // saves about 152 bytes
+
+    /* USB command restriction to boot with wheel pressed */
+    #define MINI_RESTRICT_MEMORYMGMT
+#endif
+
+// enforce feature requirements
+#if defined(MINI_RESTRICT_MEMORYMGMT)
+    #define MINI_BUTTON_AT_BOOT
 #endif
 
 /**************** HW MACROS ****************/

--- a/source_code/src/mooltipass.h
+++ b/source_code/src/mooltipass.h
@@ -40,7 +40,7 @@ extern uint8_t mp_timeout_enabled;
 extern uint8_t act_detected_flag;
 
 #if defined(MINI_VERSION) && defined(MINI_BUTTON_AT_BOOT)
-uint8_t mini_button_at_boot;
+extern uint8_t mini_button_at_boot;
 #endif
 
 /* Function prototypes */


### PR DESCRIPTION
- [x] This PR is compliant with the contributing guidelines (if not, please describe why): code is fully documented and if possible a .md file is made.
- [x] The PR text includes a **detailed explanation** (more than 50 chars)
- [x] I have thoroughly tested my contribution.

Adds a define to optionally remove the CMD_GET_RANDOM_NUMBER command.
Also adds comments in define.h about the size freed/used by these hardening features