### PR TITLE
Changes to allow building of bootloader correctly

### DIFF
--- a/source_code/Makefile
+++ b/source_code/Makefile
@@ -13,7 +13,7 @@ OBJDUMP := $(CROSS)objdump
 SIZE    := $(CROSS)size
 AR      := $(CROSS)ar
 AS      := $(CROSS)as
-BOOTLOADER   = false
+BOOTLOADER  ?= false
 
 # Mooltipass version: vMAJOR.MINOR
 VERSION := v0.8
@@ -50,11 +50,11 @@ TARGET  := mooltipass_bootloader
 OBJECTS := $(patsubst src/%.c,build/%.o, src/bootloader_main.c)
 LIBDIRS := $(addprefix src/, GUI CARD FLASH USB SPI OLEDMP UTILS AES NODEMGMT RNG PWM TOUCH LOGIC OLEDMINI)
 OBJDIRS := $(patsubst src/%.c,build/%.o, $(addprefix src/, FLASH SPI AES))
-LIBOBJS := $(foreach lib, $(OBJDIRS), $(patsubst src/%.c,build/%.o, $(wildcard $(lib)/*.c)))
+LIBOBJS := $(foreach lib, $(OBJDIRS), $(patsubst src/%.c,build/%.o, $(filter-out src/AES/aes256_ctr_test.c src/FLASH/flash_test.c src/AES/aes256_nessie_test.c, $(wildcard $(lib)/*.c))))
+DEFINES += MINI_BOOTLOADER
 
 # Special bootloader flags
-CC_FLAGS     += -DBOOT_START_ADDR=$(BOOT_START_OFFSET)
-LD_FLAGS     += -Wl,--section-start=.text=$(BOOT_START_OFFSET) $(BOOT_API_LD_FLAGS)
+LDFLAGS     += -Wl,--section-start=.text=$(BOOT_START_OFFSET) $(BOOT_API_LD_FLAGS) -nostartfiles
 
 # Flash size and bootloader section sizes of the target, in KB. These must
 # match the target's total FLASH size and the bootloader size set in the
@@ -82,7 +82,7 @@ MCU     := atmega32u4
 # Set CONFIG=DEBUG in the shell from which you invoke make to build a debug
 # build.
 CONFIG  ?= RELEASE
-DEFINES := F_CPU=16000000UL F_USB=16000000UL
+DEFINES += F_CPU=16000000UL F_USB=16000000UL
 #DEFINES := F_CPU=16000000UL F_USB=16000000UL MOOLTIPASS_VERSION="\"$(VERSION)\""
 
 CFLAGS  += -Wall -mmcu=$(MCU) -funsigned-char -funsigned-bitfields -fpack-struct
@@ -106,7 +106,7 @@ CFLAGS  += -MP
 LDFLAGS += -Wl,--gc-sections -mrelax
 LDFLAGS += -mmcu=$(MCU)
 LDFLAGS += -Wl,--start-group -Wl,-lm -Wl,--end-group
-LDFLAGS += -Wl,-Map="mooltipass.map" 
+LDFLAGS += -Wl,-Map="${TARGET}.map"
 #LDFLAGS  += -Werror
 
 ifeq ($(CONFIG), RELEASE)


### PR DESCRIPTION
Fixes #348 

Current state of the Makefile is unable to build bootloader properly.  This commit removes some test sources that were matched and making the resulting binary too large.  Also adds a define for building the bootloader, correctly names the bootloader map file, and allows BOOTLOADER= to be specified on the command line.