### PR TITLE
Update version of Safari extension

### DIFF
--- a/chrome_extension/updateSafariExtension.sh
+++ b/chrome_extension/updateSafariExtension.sh
@@ -10,3 +10,5 @@ cp -Rf background Mooltipass.safariextension/
 cp -Rf images Mooltipass.safariextension/
 cp -Rf css Mooltipass.safariextension/
 cp -Rf popups Mooltipass.safariextension/
+
+python updateSafariVersion.py

--- a/chrome_extension/updateSafariVersion.py
+++ b/chrome_extension/updateSafariVersion.py
@@ -1,0 +1,12 @@
+import json, plistlib;
+
+with open("manifest.json") as dataFile:    
+    data = json.load(dataFile)
+
+version = data["version"];
+
+infoFile = "Mooltipass.safariextension/Info.plist";
+plist = plistlib.readPlist(infoFile);
+plist["CFBundleShortVersionString"] = ".".join(version.split(".")[:2]);
+plist["CFBundleVersion"] = version.split(".")[2];
+plistlib.writePlist(plist, infoFile);


### PR DESCRIPTION
A new python script was added to update version of safari extension
from the manifest.json.

updateSafariExtension.sh calls this script.

Mac os comes with Python out of the box.
Therefore we do not need to install anything else to run the script.