### PR TITLE
Fix updating the device status

### DIFF
--- a/chrome_extension/Mooltipass.safariextension/Info.plist
+++ b/chrome_extension/Mooltipass.safariextension/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.1</string>
 	<key>CFBundleVersion</key>
-	<string>80</string>
+	<string>81</string>
 	<key>Chrome</key>
 	<dict>
 		<key>Database Quota</key>

--- a/chrome_extension/popups/js/popup_status.js
+++ b/chrome_extension/popups/js/popup_status.js
@@ -129,9 +129,11 @@ function getStatusCallback( object ) {
 
 function updateStatusInfo() {
     if( isSafari ) {
-        if ( safari.extension.globalPage ) safari.extension.globalPage.contentWindow.mooltipassEvent.onGetStatus(getStatusCallback, { id: 'safari' });
+        if ( safari.extension.globalPage && safari.extension.globalPage.contentWindow.mooltipassEvent) {
+            safari.extension.globalPage.contentWindow.mooltipassEvent.onGetStatus(getStatusCallback, { id: 'safari' });
+        }
     } else {
-        messaging( { action: "get_status" }, getStatusCallback );    
+        messaging( { action: "get_status" }, getStatusCallback );
 
         if ( typeof chrome.notifications.getPermissionLevel == 'function' ) {
             // Check if notifications are enabled


### PR DESCRIPTION
Added check for existence of mooltipassEvent.

Background page is loaded in the separate thread.

If we try to access to mooltipassEvent when it is not loaded, then
updating of status is broken.

   