### PR TITLE
chrome_extension/pkg builder: Provide document about emulation mode>

### DIFF
--- a/chrome_extension/updateCleanVersion.sh
+++ b/chrome_extension/updateCleanVersion.sh
@@ -293,7 +293,7 @@ EOF
     fi
 
     cat <<EOF 1>&2
-Usage: $prog_name [--extension-name NAME] [TARGET] [--test]
+Usage: $prog_name [OPTION]... [--extension-name NAME] [TARGET] [--test]
 where TARGET := --target {chrome | chromium | firefox} --sign-key SIGN_KEY
 
       --extension-name  name of the generated extension files
@@ -301,6 +301,11 @@ where TARGET := --target {chrome | chromium | firefox} --sign-key SIGN_KEY
       --sign-key        path to signature key file for the specific target (ie: Chromium, Firefox...)
       --target          create a clean directory for the given target chromium(default)
       --test            only perform test, no packages are created
+
+options:
+        --emulation-mode        This will set the emulate mode in the base archive
+                                (see mooltipass.device.emulation_mode under device.js)
+
 EOF
 
     exit 1


### PR DESCRIPTION
Document how to use this flag.

Related to PR #433 where documentation about the added flag was missing on the usage output.

- [x] This PR is compliant with the contributing guidelines (if not, please describe why): code is fully documented and if possible a .md file is made.
- [x] The PR text includes a **detailed explanation** (more than 50 chars)
- [x] I have thoroughly tested my contribution.