### PR TITLE
handle http auth

### DIFF
--- a/chrome_extension/background/event.js
+++ b/chrome_extension/background/event.js
@@ -523,6 +523,20 @@ mooltipassEvent.showApp = function() {
 	}
 }
 
+/*
+ * Notify httpAuth when custom HTTP Auth form is submitted.
+ */
+mooltipassEvent.onHttpAuthSubmit = function(callback, tab, credentials) {
+	httpAuth.onSubmit(credentials)
+}
+
+/*
+ * Notify httpAuth when custom HTTP Auth is cancelled.
+ */
+mooltipassEvent.onHttpAuthCancel = function(callback, tab, credentials) {
+	httpAuth.onCancel()
+}
+
 // all methods named in this object have to be declared BEFORE this!
 mooltipassEvent.messageHandlers = {
 	'update': mooltipassEvent.onUpdate,
@@ -547,6 +561,8 @@ mooltipassEvent.messageHandlers = {
 	'save_settings': mooltipassEvent.onSaveSettings,
 	'update_notify': mooltipassEvent.onUpdateNotify,
 	'stack_add': browserAction.stackAdd,
+	'http_auth_submit': mooltipassEvent.onHttpAuthSubmit,
+	'http_auth_cancel': mooltipassEvent.onHttpAuthCancel,
 	'generate_password': mooltipass.device.generatePassword,
     'set_current_tab': page.setCurrentTab,
     'cache_login': page.cacheLogin,

--- a/chrome_extension/background/init.js
+++ b/chrome_extension/background/init.js
@@ -157,7 +157,7 @@ startMooltipass = function() {
 		 */
 		if ( chrome.webRequest.onAuthRequired ) {
 			chrome.webRequest.onAuthRequired.addListener(httpAuth.handleRequest,
-				{ urls: ["<all_urls>"] }, ["asyncBlocking"]
+				{ urls: ["<all_urls>"] }, [isFirefox ? "blocking" : "asyncBlocking"]
 			);	
 		}
 	}

--- a/chrome_extension/manifest.json
+++ b/chrome_extension/manifest.json
@@ -53,7 +53,8 @@
   "web_accessible_resources": [
     "jquery.min.map",
     "images/icon_password_16.png",
-    "images/icon_password_24.png"
+    "images/icon_password_24.png",
+    "images/logo_inverted.png"
   ],
   "permissions": [
     "contextMenus",

--- a/chrome_extension/mooltipass-content.css
+++ b/chrome_extension/mooltipass-content.css
@@ -728,6 +728,9 @@ input.mp-hover-password {
         height: 24px;
         background-image: url(images/icon_password_24.png);
     }
+		.mp-popup-http-auth__logo {
+				background-image: url(images/logo_inverted.png) !important;
+		}
 }
 
 
@@ -904,4 +907,149 @@ input.mp-hover-password {
 
 .mp-genpw-dialog .login-area {
     display: none;
+}
+
+/* HTTP Auth popup */
+
+.mp-popup-http-auth {
+	position: fixed;
+	top: 0;
+	right: 0;
+	left: 0;
+	bottom: 0;
+	z-index: 9999;
+	overflow: auto;
+	font-family: "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif;
+	background-color: rgba(0, 0, 0, 0.45);
+}
+
+.mp-popup-http-auth__content {
+	margin: 100px auto;
+	padding: 50px;
+	max-width: 350px;
+	background-color: white;
+	border: solid 1px #666666;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.4);
+}
+
+.mp-popup-http-auth__form {
+	max-width: 300px;
+	margin: auto;
+}
+
+input.mp-popup-http-auth__input {
+	-webkit-appearance: none;
+	-moz-appearance: none;
+	border-radius: 0;
+	background-color: #FFFFFF;
+	border-style: solid;
+	border-width: 1px;
+	border-color: #cccccc;
+	border-radius: 0;
+	box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+	color: rgba(0, 0, 0, 0.75);
+	display: block;
+	font-family: inherit;
+	font-size: 14px;
+	height: 37px;
+	margin: 0 0 16px 0;
+	padding: 8px;
+	width: 100%;
+	-webkit-box-sizing: border-box;
+	-moz-box-sizing: border-box;
+	box-sizing: border-box;
+	-webkit-transition: border-color 0.15s linear, background 0.15s linear;
+	-moz-transition: border-color 0.15s linear, background 0.15s linear;
+	-ms-transition: border-color 0.15s linear, background 0.15s linear;
+	-o-transition: border-color 0.15s linear, background 0.15s linear;
+	transition: border-color 0.15s linear, background 0.15s linear;
+}
+
+input.mp-popup-http-auth__input:focus {
+	background: #fafafa;
+	border-color: #999999;
+	outline: none;
+}
+
+input.mp-popup-http-auth__input:focus {
+	outline: none;
+	border: 1px solid #CCC !important;
+}
+	
+.mp-popup-http-auth__logo {
+	margin: auto;
+	width: 215px;
+	height: 64px;
+	margin-bottom: 50px;
+	background-image: url(chrome-extension://__MSG_@@extension_id__/images/logo_inverted.png);
+}
+
+.mp-popup-http-auth__button {
+	-webkit-appearance: none;
+	-moz-appearance: none;
+	border-radius: 0;
+	border-style: solid;
+	border-width: 0;
+	cursor: pointer;
+	font-family: "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif;
+	font-weight: normal;
+	line-height: normal;
+	margin: 0 0 20px;
+	padding: 10px 20px 11px 20px;
+	font-size: 12px;
+	position: relative;
+	text-align: center;
+	text-decoration: none;
+	display: inline-block;
+	background-color: #60B1C7;
+	border-color: #3d96af;
+	color: #FFFFFF;
+	transition: background-color 300ms ease-out;
+}
+
+.mp-popup-http-auth__button:hover, .mp-popup-http-auth__button:focus {
+  background-color: #3d96af;
+  color: #FFFFFF;
+}
+
+.mp-popup-http-auth__button.mp-popup-http-auth__button--secondary {
+  background-color: #e7e7e7;
+  border-color: #b9b9b9;
+  color: #333333;
+}
+
+.mp-popup-http-auth__button--secondary:hover, .mp-popup-http-auth__button--secondary.secondary:focus {
+  background-color: #b9b9b9;
+  color: #333333;
+}
+
+.mp-popup-http-auth__label {
+	color: #4d4d4d;
+	cursor: pointer;
+	display: block;
+	font-size: 14px;
+	font-weight: normal;
+	line-height: 1.5;
+	margin-bottom: 0;
+	text-align: left;
+}
+
+.mp-popup-http-auth__submit {
+	float: right;
+}
+
+.mp-popup-http-auth__cancel {
+	margin-right: 20px;
+}
+
+.mp-popup-http-auth__controls {
+	text-align: right;
+}
+
+.mp-popup-http-auth__notice {
+	display: none;
+	color: #f18888;
+	margin-bottom: 10px;
+	text-align: center;
+	font-size: 14px;
 }

--- a/chrome_extension/vendor/mooltipass/device.js
+++ b/chrome_extension/vendor/mooltipass/device.js
@@ -298,39 +298,37 @@ mooltipass.device.sendCredentialRequestMessageFromQueue = function()
             // Put everything in a timeout to avoid duplicate requests
             setTimeout(function()
             {
+                var credentials = [];
+                
                 for (var i = 0; i < mooltipass.device.emulation_credentials.length; i++)
                 {
                     if (mooltipass.device.emulation_credentials[i]["domain"] == mooltipass.device.retrieveCredentialsQueue[0].domain)
                     {
                         if (background_debug_msg > 3) mpDebug.log("%c Emulation mode: found credential in buffer:", mpDebug.css('00ff00'), mooltipass.device.emulation_credentials[i]);
-                        setTimeout(function() 
-                        {
-                            try
-                            {
-                                mooltipass.device.retrieveCredentialsQueue[0].callback([
-                                    {
-                                        Login: mooltipass.device.emulation_credentials[i]["login"],
-                                        Name: '<name>',
-                                        Uuid: '<Uuid>',
-                                        Password: mooltipass.device.emulation_credentials[i]["password"],
-                                        StringFields: []
-                                    }
-                                ], mooltipass.device.retrieveCredentialsQueue[0].tabid == 'safari'?mooltipass.device.retrieveCredentialsQueue[0].tab:mooltipass.device.retrieveCredentialsQueue[0].tabid );
-                            }
-                            catch(err)
-                            {
-                                //console.log( err );
-                            }
-                            // Treat other pending requests
-                            mooltipass.device.retrieveCredentialsQueue.shift();
-                            mooltipass.device.sendCredentialRequestMessageFromQueue();
-                        }, 2000);
-                        return;
+                        credentials.push(
+                          {
+                              Login: mooltipass.device.emulation_credentials[i]["login"],
+                              Name: '<name>',
+                              Uuid: '<Uuid>',
+                              Password: mooltipass.device.emulation_credentials[i]["password"],
+                              StringFields: []
+                          }
+                        );
                     }
                 }
                 if (background_debug_msg > 3) mpDebug.log("%c Emulation mode: nothing in buffer!", mpDebug.css('00ff00'));
-                mooltipass.device.retrieveCredentialsQueue.shift();
-                mooltipass.device.sendCredentialRequestMessageFromQueue();
+                
+                setTimeout(function()
+                {
+                    try {
+                        mooltipass.device.retrieveCredentialsQueue[0].callback(credentials,
+                          mooltipass.device.retrieveCredentialsQueue[0].tabid == 'safari'?mooltipass.device.retrieveCredentialsQueue[0].tab:mooltipass.device.retrieveCredentialsQueue[0].tabid );
+                    } catch(err) {}
+                    
+                    // Treat other pending requests
+                    mooltipass.device.retrieveCredentialsQueue.shift();
+                    mooltipass.device.sendCredentialRequestMessageFromQueue();
+                }, 2000);
             }, 300);
         }
         else if (mooltipass.device.connectedToExternalApp) 


### PR DESCRIPTION
Finally got it working for both Chrome and Firefox!

* In emulation mode callback for _mooltipass.device.retrieveCredentials_ didn't execute that's why there was no auth popup.
* Stuck with a problem that it's impossible to get `Authorization` header while we intercept response. But we can create our custom popup and handle http authorization by ourself. I used window.prompt now, will add popup later.
* Firefox doesn't execute callback because of the _asyncBlocking_ setting. It's not supported and I will see the differences between Chrome's _asyncBlocking_ and Firefox's _blocking_.