### PR TITLE
revisited submit and missing form data

### DIFF
--- a/chrome_extension/background/init.js
+++ b/chrome_extension/background/init.js
@@ -139,13 +139,11 @@ startMooltipass = function() {
 
 			// Intercept posts
 			if (details.method == "POST") {
-				// Deal both with RAW DATA and FORM DATA
-				if (details && details.type === "xmlhttprequest") { // Raw data (multipart posts, etc)
-					if ( details.requestBody && details.requestBody.raw && details.requestBody.raw[0]) {
-						var buffer = details.requestBody.raw[0].bytes;
-						var parsed = arrayBufferToData.toJSON(buffer);
-						if ( details.tabId ) chrome.tabs.sendMessage( details.tabId, {action: 'post_detected', post_data: parsed });	
-					} 
+				// Deal with RAW DATA
+				if (details.requestBody && details.requestBody.raw && details.requestBody.raw[0]) {
+					var buffer = details.requestBody.raw[0].bytes;
+					var parsed = arrayBufferToData.toJSON(buffer);
+					if ( details.tabId ) chrome.tabs.sendMessage( details.tabId, {action: 'post_detected', post_data: parsed });	
 				} else { // Standard POST
 					chrome.tabs.sendMessage( details.tabId, {action: 'post_detected', details: details});	
 				}

--- a/chrome_extension/background/init.js
+++ b/chrome_extension/background/init.js
@@ -139,11 +139,14 @@ startMooltipass = function() {
 
 			// Intercept posts
 			if (details.method == "POST") {
-				// Deal with RAW DATA
-				if (details.requestBody && details.requestBody.raw && details.requestBody.raw[0]) {
-					var buffer = details.requestBody.raw[0].bytes;
-					var parsed = arrayBufferToData.toJSON(buffer);
-					if ( details.tabId ) chrome.tabs.sendMessage( details.tabId, {action: 'post_detected', post_data: parsed });	
+				// Deal both with RAW DATA and FORM DATA
+				// If we notice the extension being slow because of it intercepting too much data, uncomment the following line
+				//if (details && details.type === "xmlhttprequest") { // Raw data (multipart posts, etc)
+					if (details && details.requestBody && details.requestBody.raw && details.requestBody.raw[0]) {
+						var buffer = details.requestBody.raw[0].bytes;
+						var parsed = arrayBufferToData.toJSON(buffer);
+						if ( details.tabId ) chrome.tabs.sendMessage( details.tabId, {action: 'post_detected', post_data: parsed });	
+					//} 
 				} else { // Standard POST
 					chrome.tabs.sendMessage( details.tabId, {action: 'post_detected', details: details});	
 				}

--- a/chrome_extension/vendor/mooltipass/mcCombinations.js
+++ b/chrome_extension/vendor/mooltipass/mcCombinations.js
@@ -941,9 +941,13 @@ mcCombinations.prototype.doSubmit = function doSubmit( currentForm ) {
 				// Special cases.
 				/identifierNext/i,
 				/passwordNext/i,
-				/verify_user_btn/i],
-				
-			IGNORE_PATTERNS = [/id=".*?search.*?"/i],
+				/verify_user_btn/i
+			],
+			
+			IGNORE_PATTERNS = [
+				/forgotpassword/i,
+				/id=".*?search.*?"/i
+			],
 			
 			// Selectors are ordered by priority, first ones are more important.
 			BUTTON_SELECTORS = ['button:visible', '[type="submit"]:visible', '[role="button"]:visible', 'a:visible', 'div:visible']

--- a/chrome_extension/vendor/mooltipass/mcCombinations.js
+++ b/chrome_extension/vendor/mooltipass/mcCombinations.js
@@ -936,7 +936,7 @@ mcCombinations.prototype.doSubmit = function doSubmit( currentForm ) {
 	
 	var ACCEPT_PATTERNS = [/submit/i, /login/i, /identifierNext/i, /passwordNext/i, /verify_user_btn/i],
 			IGNORE_PATTERNS = [/id=".*?search.*?"/i],
-			BUTTON_SELECTOR = 'button:visible, [type="submit"]:visible, a:visible, [role="button"]:visible'
+			BUTTON_SELECTOR = 'button:visible, [type="submit"]:visible, [role="button"]:visible'
 			
 	// Check that form element is in DOM. There are cases when form has been reattached.
 	var $root = mpJQ(mpJQ.contains(document, currentForm.element[0]) ? currentForm.element : mpJQ('body')),
@@ -961,7 +961,10 @@ mcCombinations.prototype.doSubmit = function doSubmit( currentForm ) {
 		// Select innermost element to trigger click. Event will be propagated anyway.
 		submitButton = mpJQ(submitButton).find(':not(:has(*))')[0] || submitButton
 		
-		mpJQ(submitButton).trigger('click')
+		// Button can be disabled, waiting for update.
+		setTimeout(function() {
+			mpJQ(submitButton).trigger('click')
+		}, 100)
 	} else {
 		// If we haven't found submit button, let's trigger submit event on the form.
 		mpJQ(currentForm.element).trigger('submit')

--- a/chrome_extension/vendor/mooltipass/mcCombinations.js
+++ b/chrome_extension/vendor/mooltipass/mcCombinations.js
@@ -934,13 +934,24 @@ mcCombinations.prototype.doSubmit = function doSubmit( currentForm ) {
 	
 	// Trying to find submit button and trigger click event.
 	
-	var ACCEPT_PATTERNS = [/submit/i, /login/i, /sign/i, /identifierNext/i, /passwordNext/i, /verify_user_btn/i],
+	var ACCEPT_PATTERNS = [
+				// Common patterns.
+				/submit/i, /login/i, /sign/i,
+				
+				// Special cases.
+				/identifierNext/i,
+				/passwordNext/i,
+				/verify_user_btn/i],
+				
 			IGNORE_PATTERNS = [/id=".*?search.*?"/i],
+			
 			// Selectors are ordered by priority, first ones are more important.
 			BUTTON_SELECTORS = ['button:visible', '[type="submit"]:visible', '[role="button"]:visible', 'a:visible', 'div:visible']
 			
 	// Check that form element exists and in DOM. There are cases when form has been reattached.
-	var $root = mpJQ((currentForm.element && mpJQ.contains(document, currentForm.element[0])) ? currentForm.element : mpJQ('body')),
+	var $root = currentForm.element && mpJQ.contains(document, currentForm.element[0])
+						? currentForm.element
+						: mpJQ('body'),
 			submitButton = null
 	
 	// Traversing DOM from form element to top in case there is a button outside the form.


### PR DESCRIPTION
New _doSubmit_ implementation. Now we focus on buttons for submitting forms with more flexible detection by adding `ACCEPT_PATTERNS` and `IGNORE_PATTERNS`. Also there is a fix for missing post requests from previous pull request.

Tested on the recently reported sites:
* https://web.tresorit.com/login
* https://www.vodafone.de/ussa/login/login.ftel
* https://nordinary-com.netcup-mail.de/SOGo/
* https://accounts.google.com/ServiceLogin

Also setting tests now.