### PR TITLE
fix position for password popover

### DIFF
--- a/chrome_extension/mooltipass-content.css
+++ b/chrome_extension/mooltipass-content.css
@@ -756,7 +756,7 @@ input.mp-hover-password {
 }
 
 .mp-genpw-dialog .mooltipass-box {
-    position: absolute;
+    position: fixed;
     background-color: rgba(255, 255, 255, 1);
     border: 1px solid rgb(30,30,30);
     font-family: 'Helvetica Neue', 'Lucida Grande', sans-serif !important;


### PR DESCRIPTION
Discovered this issue on komoot.de – we calculate position for tooltip based on viewport dimensions and if page isn't scrolled to top tooltip will be at wrong position.