### PR TITLE
revisited http auth

### DIFF
--- a/chrome_extension/background/event.js
+++ b/chrome_extension/background/event.js
@@ -530,13 +530,6 @@ mooltipassEvent.onHttpAuthSubmit = function(callback, tab, credentials) {
 	httpAuth.onSubmit(credentials)
 }
 
-/*
- * Notify httpAuth when custom HTTP Auth is cancelled.
- */
-mooltipassEvent.onHttpAuthCancel = function(callback, tab, credentials) {
-	httpAuth.onCancel()
-}
-
 // all methods named in this object have to be declared BEFORE this!
 mooltipassEvent.messageHandlers = {
 	'update': mooltipassEvent.onUpdate,
@@ -562,7 +555,6 @@ mooltipassEvent.messageHandlers = {
 	'update_notify': mooltipassEvent.onUpdateNotify,
 	'stack_add': browserAction.stackAdd,
 	'http_auth_submit': mooltipassEvent.onHttpAuthSubmit,
-	'http_auth_cancel': mooltipassEvent.onHttpAuthCancel,
 	'generate_password': mooltipass.device.generatePassword,
     'set_current_tab': page.setCurrentTab,
     'cache_login': page.cacheLogin,

--- a/chrome_extension/background/httpauth.js
+++ b/chrome_extension/background/httpauth.js
@@ -1,65 +1,73 @@
-var httpAuth = httpAuth || {};
+var httpAuth = httpAuth || {}
 
-httpAuth.callback = null
-httpAuth.contentReady = false
+httpAuth.credentials = null
+httpAuth.url = null
+httpAuth.tabId = null
 
 httpAuth.onSubmit = function(credentials) {
-  httpAuth.callback({
-      authCredentials: {
-          username: credentials.login,
-          password: credentials.password
-      }
-  });
-};
-
-httpAuth.onCancel = function() {
-  httpAuth.callback({ cancel: true });
-};
+  httpAuth.credentials = credentials
+  chrome.tabs.update(httpAuth.tabId, { url: httpAuth.url })
+}
 
 httpAuth.handleRequest = function(details, callback) {
     // Cancel requests which are initiated not from tabs.
     if (!page.tabs[details.tabId]) {
-      callback({ cancel: true })
-      // Firefox expects this object on return.
-      return { cancel: true }
+      if (!isFirefox) {
+        callback({ cancel: true })
+        return
+      } else {
+        // Firefox expects this object on return.
+        return { cancel: true }
+      }
+    }
+    
+    // Enter credentials that we saved last time.
+    if (httpAuth.credentials) {
+      var credentials = httpAuth.credentials
+      httpAuth.credentials = null
+      
+      if (!isFirefox) {
+        callback({
+          authCredentials: {
+            username: credentials.login,
+            password: credentials.password
+          }
+        })
+        return
+      } else {
+        return {
+          authCredentials: {
+            username: credentials.login,
+            password: credentials.password
+          }
+        }
+      }
     }
     
     // For the first HTTP Auth request we are opening http-auth.html with auth popup
-    // and then redirecting user to the requested url again.
-    if (!httpAuth.contentReady) {
-      chrome.tabs.update(details.tabId, { url: chrome.extension.getURL('http-auth.html') })
-      httpAuth.contentReady = true
-      
-      // Waiting when content scripts are loaded.
-      setTimeout(function() {
-        chrome.tabs.update(details.tabId, { url: details.url })
-        
-        // Resetting contentReady for future http auth requests.
-        setTimeout(function() {
-          httpAuth.contentReady = false
-        }, 1000)
-        
-        messaging({
-          action: "show_http_auth",
-          args: [{
-            url: details.isProxy
-                 ? 'proxy://' + details.challenger.host + ':' + details.challenger.port
-                 : details.url
-          }]
-        }, details.tabId);
-      }, 100)
-      
+    // and redirecting user to the requested url after form is submitted.
+    chrome.tabs.update(details.tabId, { url: chrome.extension.getURL('http-auth.html') })
+    
+    httpAuth.url = details.url
+    httpAuth.tabId = details.tabId
+    
+    // Waiting when content scripts are loaded.
+    setTimeout(function() {
+      messaging({
+        action: "show_http_auth",
+        args: [{
+          isProxy: details.isProxy,
+          proxy: isFirefox ? details.ip : details.challenger.host + ':' + details.challenger.port,
+          url:  details.url
+        }]
+      }, details.tabId);
+    }, 500)
+    
+    if (!isFirefox) {
       callback({ cancel: true })
+      return
+    } else {
       // Firefox expects this object on return.
       return { cancel: true }
-    }
-    
-    httpAuth.callback = callback
-    if (isFirefox) {
-      return new Promise(function(resolve) {
-        httpAuth.callback = function(credentials) {
-          resolve(credentials);
-        }
-      })
     }
 }

--- a/chrome_extension/background/httpauth.js
+++ b/chrome_extension/background/httpauth.js
@@ -1,12 +1,9 @@
 var httpAuth = httpAuth || {}
 
 httpAuth.credentials = null
-httpAuth.url = null
-httpAuth.tabId = null
 
 httpAuth.onSubmit = function(credentials) {
   httpAuth.credentials = credentials
-  chrome.tabs.update(httpAuth.tabId, { url: httpAuth.url })
 }
 
 httpAuth.handleRequest = function(details, callback) {
@@ -46,22 +43,13 @@ httpAuth.handleRequest = function(details, callback) {
     
     // For the first HTTP Auth request we are opening http-auth.html with auth popup
     // and redirecting user to the requested url after form is submitted.
-    chrome.tabs.update(details.tabId, { url: chrome.extension.getURL('http-auth.html') })
-    
-    httpAuth.url = details.url
-    httpAuth.tabId = details.tabId
-    
-    // Waiting when content scripts are loaded.
-    setTimeout(function() {
-      messaging({
-        action: "show_http_auth",
-        args: [{
-          isProxy: details.isProxy,
-          proxy: isFirefox ? details.ip : details.challenger.host + ':' + details.challenger.port,
-          url:  details.url
-        }]
-      }, details.tabId);
-    }, 500)
+    chrome.tabs.update(details.tabId, {
+      url: chrome.extension.getURL('http-auth.html') + '?' + encodeURIComponent(JSON.stringify({
+        isProxy: details.isProxy,
+        proxy: isFirefox ? details.ip : details.challenger.host + ':' + details.challenger.port,
+        url:  details.url
+      }))
+    })
     
     if (!isFirefox) {
       callback({ cancel: true })

--- a/chrome_extension/http-auth.html
+++ b/chrome_extension/http-auth.html
@@ -11,5 +11,27 @@
   <script src="mooltipass-content.js"></script>
 </head>
 <body>
+  <div class="mp-popup-http-auth">
+  	<div class="mp-popup-http-auth__content">
+  		<div class="mp-popup-http-auth__logo"></div>
+  		<div class="mp-popup-http-auth__notice">Authorizing at <span></span></div>
+  		
+  		<form class="mp-popup-http-auth__form">
+  			<div class="mp-popup-http-auth__form-row">
+  				<div class="mp-popup-http-auth__label">Login</div>
+  				<input class="mp-popup-http-auth__input" type="text" name="login">
+  			</div>
+  				
+  			<div class="mp-popup-http-auth__form-row">
+  				<div class="mp-popup-http-auth__label">Password</div>
+  				<input class="mp-popup-http-auth__input" type="password" name="password">
+  			</div>
+  				
+  			<div class="mp-popup-http-auth__controls">
+  				<button class="mp-popup-http-auth__button mp-popup-http-auth__submit" type="submit">Login</button>
+  			</div>
+  		</form>
+  	</div>
+  </div>
 </body>
 </html>

--- a/chrome_extension/mooltipass-content.css
+++ b/chrome_extension/mooltipass-content.css
@@ -1034,14 +1034,6 @@ input.mp-popup-http-auth__input:focus {
 	text-align: left;
 }
 
-.mp-popup-http-auth__submit {
-	float: right;
-}
-
-.mp-popup-http-auth__cancel {
-	margin-right: 20px;
-}
-
 .mp-popup-http-auth__controls {
 	text-align: right;
 }

--- a/chrome_extension/mooltipass-content.js
+++ b/chrome_extension/mooltipass-content.js
@@ -1710,57 +1710,6 @@ cipEvents.startEventHandling = function() {
 			else if (req.action == "captcha_detected") {
 				cip.formHasCaptcha = true;
 			}
-			else if (req.action == "show_http_auth") {
-				mpJQ('body').append(
-					'<div class="mp-popup-http-auth">' +
-						'<div class="mp-popup-http-auth__content">' +
-							'<div class="mp-popup-http-auth__logo"></div>' +
-							'<div class="mp-popup-http-auth__notice">Authorizing at <span></span></div>' +
-							
-							'<form class="mp-popup-http-auth__form">' +
-								'<div class="mp-popup-http-auth__form-row">' +
-									'<div class="mp-popup-http-auth__label">Login</div>' +
-									'<input class="mp-popup-http-auth__input" type="text" name="login">' +
-								'</div>' +
-									
-								'<div class="mp-popup-http-auth__form-row">' +
-									'<div class="mp-popup-http-auth__label">Password</div>' +
-									'<input class="mp-popup-http-auth__input" type="password" name="password">' +
-								'</div>' +
-									
-								'<div class="mp-popup-http-auth__controls">' +
-									'<button class="mp-popup-http-auth__button mp-popup-http-auth__submit" type="submit">Login</button>' +
-								'</div>' +
-							'</form>' +
-						'</div>' +
-					'</div>'
-				)
-				
-				// Set url as action attribute of the form, so mcCombs will
-				// save credentials for the right url.
-				mpJQ('.mp-popup-http-auth__form').attr('action', 
-					req.args[0].isProxy
-					? 'proxy://' + req.args[0].proxy
-					: req.args[0].url
-				)
-				mpJQ('.mp-popup-http-auth__notice span').text(
-					req.args[0].isProxy
-						? req.args[0].proxy
-						: new URL(req.args[0].url).hostname
-				)
-				
-				mpJQ('.mp-popup-http-auth__form').on('submit', function(event) {
-					event.preventDefault();
-					
-					messaging({
-						action: 'http_auth_submit',
-						args: [{
-							login: mpJQ('.mp-popup-http-auth__form [name="login"]').val(),
-							password: mpJQ('.mp-popup-http-auth__form [name="password"]').val()
-						}]
-					});
-				})
-			}
 		}
 	};
 
@@ -1821,6 +1770,44 @@ if (!stopInitialization) {
 	mcCombs.settings.debugLevel = content_debug_msg;
 
 	messaging( {'action': 'content_script_loaded' } );
+	
+	handleHTTPAuth()
+}
+
+function handleHTTPAuth() {
+	// We need to execute only when http-auth.html is opened.
+	if (window.location.origin + window.location.pathname != chrome.extension.getURL('http-auth.html')) return
+	
+	$(function() {
+		var data = JSON.parse(decodeURIComponent(window.location.search.slice(1)))
+		
+		// Set url as action attribute of the form, so mcCombs will
+		// save credentials for the right url.
+		mpJQ('.mp-popup-http-auth__form').attr('action', 
+			data.isProxy
+			? 'proxy://' + data.proxy
+			: data.url
+		)
+		mpJQ('.mp-popup-http-auth__notice span').text(
+			data.isProxy
+				? data.proxy
+				: new URL(data.url).hostname
+		)
+		
+		mpJQ('.mp-popup-http-auth__form').on('submit', function(event) {
+			event.preventDefault();
+			
+			messaging({
+				action: 'http_auth_submit',
+				args: [{
+					login: mpJQ('.mp-popup-http-auth__form [name="login"]').val(),
+					password: mpJQ('.mp-popup-http-auth__form [name="password"]').val()
+				}]
+			});
+			
+			window.location.href = data.url
+		})
+	})
 }
 
 var mpDialog = {

--- a/chrome_extension/mooltipass-content.js
+++ b/chrome_extension/mooltipass-content.js
@@ -1730,7 +1730,6 @@ cipEvents.startEventHandling = function() {
 									
 								'<div class="mp-popup-http-auth__controls">' +
 									'<button class="mp-popup-http-auth__button mp-popup-http-auth__submit" type="submit">Login</button>' +
-									'<button class="mp-popup-http-auth__button mp-popup-http-auth__button--secondary mp-popup-http-auth__cancel">Cancel</button>' +
 								'</div>' +
 							'</form>' +
 						'</div>' +
@@ -1739,8 +1738,16 @@ cipEvents.startEventHandling = function() {
 				
 				// Set url as action attribute of the form, so mcCombs will
 				// save credentials for the right url.
-				mpJQ('.mp-popup-http-auth__form').attr('action', req.args[0].url)
-				mpJQ('.mp-popup-http-auth__notice span').text((new URL(req.args[0].url).hostname))
+				mpJQ('.mp-popup-http-auth__form').attr('action', 
+					req.args[0].isProxy
+					? 'proxy://' + req.args[0].proxy
+					: req.args[0].url
+				)
+				mpJQ('.mp-popup-http-auth__notice span').text(
+					req.args[0].isProxy
+						? req.args[0].proxy
+						: new URL(req.args[0].url).hostname
+				)
 				
 				mpJQ('.mp-popup-http-auth__form').on('submit', function(event) {
 					event.preventDefault();
@@ -1752,10 +1759,6 @@ cipEvents.startEventHandling = function() {
 							password: mpJQ('.mp-popup-http-auth__form [name="password"]').val()
 						}]
 					});
-				})
-				
-				mpJQ('.mp-popup-http-auth__cancel').on('click', function() {
-					messaging({ action: 'http_auth_cancel' });
 				})
 			}
 		}


### PR DESCRIPTION
Haven't got working HTTP Auth for proxy in firefox, somehow handler doesn't execute. But web http auth works well.

Test cases:

1. HTTP Auth for web service with direct link
* Go to push.org.ru/grisha/auth/success
* Redirecting to _http-auth.html_
* Enter credentials (me:me)
* Credentials should be saved for auth url
* Redirecting to succes page

2. HTTP Auth for web service with indirect link
* Go to push.org.ru/grisha/auth
* Click AUTH button
* Redirecting to _http-auth.html_
* Enter credentials (me:me)
* Credentials should be saved for auth url
* Redirecting to success page

3. HTTP Auth for proxy
* Set proxy in settings
* Open any url
* Redirecting to _http-auth.html_
* Enter credentials
* Credentials should be saved for proxy address
* Redirecting to the previous url
