### PR TITLE
cancel requests which are initiated not from tabs

### DIFF
--- a/chrome_extension/background/httpauth.js
+++ b/chrome_extension/background/httpauth.js
@@ -8,7 +8,7 @@ httpAuth.onSubmit = function(credentials) {
 
 httpAuth.handleRequest = function(details, callback) {
     // Cancel requests which are initiated not from tabs.
-    if (!page.tabs[details.tabId]) {
+    if (details.tabId == -1) {
       if (!isFirefox) {
         callback({ cancel: true })
         return


### PR DESCRIPTION
There was an issue with Chrome – HTTP Auth request executed before we update information about tabs, that's why request was cancelled when we try to open link from bookmarks bar in a new tab.