### PR TITLE
fixed dropbox and komoot

### DIFF
--- a/sauce_labs_tests/src/test/java/mooltipass/automatedTest/pageObjects/DropBox.java
+++ b/sauce_labs_tests/src/test/java/mooltipass/automatedTest/pageObjects/DropBox.java
@@ -22,7 +22,7 @@ public class DropBox extends AbstractPage{
 
 	@FindBy(xpath = "//input[@name='login_password']")
 	private WebElement password;
-	@FindBy(xpath = "//form[@action='/ajax_login']//button[@class='login-button button-primary']//div[@class='sign-in-text']")
+	@FindBy(xpath = "//form[@action='/ajax_login']//button[@type='submit']//div[@class='sign-in-text']")
 	private WebElement submitLogin;
 	
 	@FindBy(xpath = "//button[@aria-label='Account menu']")

--- a/sauce_labs_tests/src/test/java/mooltipass/automatedTest/pageObjects/Komoot.java
+++ b/sauce_labs_tests/src/test/java/mooltipass/automatedTest/pageObjects/Komoot.java
@@ -24,7 +24,7 @@ public class Komoot extends AbstractPage{
 	@FindBy(xpath = "//input[@id='password']")
 	private WebElement password;
 
-	@FindBy(xpath = "//button[text()='Anmelden']")
+	@FindBy(xpath = "//span[text()='Anmelden']")
 	private WebElement submitLogin;
 	
 	@FindBy(xpath = "//a[text()='Abmelden']")


### PR DESCRIPTION
Fixes #\<GitHub-issue-number\>.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [ ] This PR is compliant with the contributing guidelines (if not, please describe why): code is fully documented and if possible a .md file is made.
- [ ] The PR text includes a **detailed explanation** (more than 50 chars)
- [ ] I have thoroughly tested my contribution.

\<Description of and rational behind this PR\>

**In case of a PR concerning the Mooltipass extension:**  
The following test procedure should be done, in the following order.  
  
1) Recall functionality test (Mooltipass unlocked):  
- visit a website you have credentials for  
- make sure you get prompted by your mooltipass  
- accept the credentials sending request  
- make sure you are logged in  
  
2) Storage functionality test (Mooltipass unlocked):  
- visit a website you don't have credentials for  
- fill the username and password field, submit  
- make sure the mooltipass prompts you for password storage **once**  
- accept the credentials storage request  
- run test 1) to make sure credentials are correctly stored  
  
3) Cancel functionality test (Mooltipass unlocked):  
- visit a website you have credentials for  
- make sure you get prompted by your mooltipass   
- do not accept the credentials sending request, close the tab  
- make sure the prompt gets removed on the mooltipass  
  
4) Credentials requests queue test (Mooltipass **locked**)  
- visit a website you have credentials for  
- unlock your mooltipass  
- make sure you get prompted by your mooltipass   
  
5) Credentials requests queue test (Mooltipass unlocked)  
- visit a website A you have credentials for  
- make sure you get prompted by your mooltipass   
- do not accept the credentials sending request  
- visit a website B you have credentials for  
- close the tab containing the website A  
- make sure the first prompt is cancelled on the mooltipass  
- make sure another prompt for website B is displayed on the mooltipass  
   