### PR TITLE
sites compatibility

### DIFF
--- a/chrome_extension/mooltipass-content.js
+++ b/chrome_extension/mooltipass-content.js
@@ -414,9 +414,7 @@ cipFields.setFormUniqueId = function(field) {
 }
 
 cipFields.prepareId = function(id) {
-	return id.replace(/[:#.,\[\]\(\)' "]/g, function(m) {
-												return "\\"+m
-											});
+	return id.replace(/[:#.,\[\]\(\)' "]/g, '');
 }
 
 cipFields.getAllFields = function() {

--- a/chrome_extension/mooltipass-content.js
+++ b/chrome_extension/mooltipass-content.js
@@ -1587,6 +1587,9 @@ cipEvents.startEventHandling = function() {
 				definedCredentialFields.username = req.args.username || definedCredentialFields.username
 				definedCredentialFields.password = req.args.password || definedCredentialFields.password
 				definedCredentialFields.fields = req.args.fieldsIds || definedCredentialFields.fields
+				
+				// Trigger mcCombs to re-evaluate combinations.
+				mcCombs.init();
 			}
 			else if (req.action == "custom_credentials_selection_cancelled") {
 				cip.settings["defined-credential-fields"][document.location.origin] = null
@@ -1595,6 +1598,9 @@ cipEvents.startEventHandling = function() {
 					password: null,
 					fields: {}
 				}
+				
+				// Trigger mcCombs to re-evaluate combinations.
+				mcCombs.init();
 			}
 		}
 	};

--- a/chrome_extension/vendor/mooltipass/mcCombinations.js
+++ b/chrome_extension/vendor/mooltipass/mcCombinations.js
@@ -1242,6 +1242,7 @@ mcCombinations.prototype.retrieveCredentialsCallback = function (credentials) {
 		/login/i,
 		/sign/i,
 		/connexion/i,
+		/connecter/i,
 		/identifierNext/i,
 		/passwordNext/i,
 		/verify_user_btn/i,

--- a/chrome_extension/vendor/mooltipass/mcCombinations.js
+++ b/chrome_extension/vendor/mooltipass/mcCombinations.js
@@ -1013,6 +1013,7 @@ mcCombinations.prototype.setUniqueId = function( element ) {
 	if(element && !element.attr("data-mp-id")) {
 		var elementId = element.attr("id");
 		if( elementId ) {
+			elementId = elementId.replace(/[:#.,\[\]\(\)' "]/g, '');
 			element.attr("data-mp-id", elementId);
 			return;
 		} else {

--- a/chrome_extension/vendor/mooltipass/mcCombinations.js
+++ b/chrome_extension/vendor/mooltipass/mcCombinations.js
@@ -167,6 +167,35 @@ var extendedCombinations = {
 			}
 		}
 	},
+	soundcloud: function( forms ) {
+		if ( mcCombs.getAllForms() == 0 ) return;
+		for( form in forms ) {
+			var currentForm = forms[ form ];
+			if ( currentForm.element ) { // Skip noform form
+				currentForm.combination = {
+					special: true,
+					fields: {
+						username: '',
+						password: ''
+					},
+					savedFields: {
+						username: '',
+						password: ''
+					},
+					autoSubmit: false
+				}
+
+				if ( mpJQ('input[name=password]:visible').length > 0 ) {
+					currentForm.combination.fields.password = mpJQ('input[name=password]');
+					currentForm.combination.autoSubmit = true;
+				} 
+				if ( mpJQ('input[name=username]:visible').length > 0 ) {
+					currentForm.combination.fields.username = mpJQ('input[name=username]');
+					currentForm.combination.autoSubmit = true;
+				}
+			}
+		}
+	},
 	yahoo: function( forms ) {
 		if ( mcCombs.getAllForms() == 0 ) return;
 		for( form in forms ) {
@@ -320,6 +349,12 @@ mcCombinations.prototype.possibleCombinations = [
 		combinationName: 'Google Two Page Login Procedure',
 		requiredUrl: 'accounts.google.com',
 		callback: extendedCombinations.google
+	},
+	{
+		combinationId: 'soundcloudTwoPageAuth',
+		combinationName: 'SoundCloud Two Page Login Procedure',
+		requiredUrl: 'soundcloud.com',
+		callback: extendedCombinations.soundcloud
 	},
 	{
 		combinationId: 'evernoteTwoPageAuth',

--- a/chrome_extension/vendor/mooltipass/mcCombinations.js
+++ b/chrome_extension/vendor/mooltipass/mcCombinations.js
@@ -1037,6 +1037,7 @@ mcCombinations.prototype.isAvailableField = function($field) {
 		&& !$field.is(':disabled')
 		&& $field.css("visibility") != "collapsed"
 		&& $field.css("visibility") != "collapsed"
+		&& $field.attr('aria-hidden') != 'true'
 	);
 }
 
@@ -1270,6 +1271,7 @@ mcCombinations.prototype.retrieveCredentialsCallback = function (credentials) {
 		'button:visible',
 		'[role="button"]:visible',
 		'a:visible',
+		'input[onclick]:visible',
 		'div[onclick]:visible'
 	]
 	

--- a/chrome_extension/vendor/mooltipass/mcCombinations.js
+++ b/chrome_extension/vendor/mooltipass/mcCombinations.js
@@ -426,7 +426,7 @@ mcCombinations.prototype.possibleCombinations = [
 				mapsTo: 'username'
 			},
 			{
-				selector: 'input[type=password]',
+				selector: 'input[type=password],input[realtype=password]',
 				mapsTo: 'password'
 			},
 		],

--- a/chrome_extension/vendor/mooltipass/mcCombinations.js
+++ b/chrome_extension/vendor/mooltipass/mcCombinations.js
@@ -3,52 +3,6 @@
  *
  */
 var extendedCombinations = {
-	trillian: function (forms) {
-        	var validateCredentials = function () {
-            		var username = mpJQ('#x_loginUsername')[0].value;
-            		var password = mpJQ('#x_loginPassword')[0].value;
-            		if (username.length > 0 && password.length > 0) {
-                		messaging({
-                    			'action': 'update_notify',
-                    			'args': [username, 
-						password, 
-						'https://www.trillian.im/api/user/0.1/index.php/signin'
-						]
-                		});
-            		}
-        	};
-        	mpJQ('#x_loginUsername').on('blur', validateCredentials);
-        	mpJQ('#x_loginPassword').on('blur', validateCredentials);
-        	for (form in forms) {
-            		var currentForm = forms[form];
-            		currentForm.combination = {
-                		special: true,
-                		fields: {
-                    			username: '',
-                    			password: ''
-                		},
-                		savedFields: {
-                    			username: '',
-                    			password: ''
-                		},
-                		autoSubmit: true,
-                		submitHandler: function (credentials) {
-                    			mpJQ('#x_loginUsername')[0].value = credentials.Login;
-                    			mpJQ('#x_loginPassword')[0].value = credentials.Password;
-                    			setTimeout(function () {
-                        			mpJQ('.button')[0].click();
-                    			}, 100);
-                		}
-            		};
-
-            		if (mpJQ('#x_loginUsername').length > 0) {
-                		currentForm.combination.fields.username = mpJQ('#x_loginUsername');
-            		}
-            		if (mpJQ('#x_loginPassword').length > 0) {
-                		currentForm.combination.fields.password = mpJQ('#x_loginPassword');
-            		}
-        	}
-    	},
 	skype: function( forms ) {
 		//console.log('skype combination');
 		if ( mcCombs.getAllForms() == 0 ) return;
@@ -311,26 +265,6 @@ mcCombinations.prototype.gotSettings = function( response ) {
 * Array containing all the possible combinations we support
 */
 mcCombinations.prototype.possibleCombinations = [
-	{
-		combinationId: 'trillianLogin',
-		combinationName: 'Simple Trillian Login',
-		requiredUrl: 'www.trillian.im',
-		requiredFields: [
-            		{
-                		selector: 'input[type=text],input:not([type])',
-                		mapsTo: 'username'
-            		},
-            		{
-                		selector: 'input[type=password]',
-                		mapsTo: 'password'
-            		},
-        	],
-        	scorePerMatch: 50,
-        	score: 0,
-        	autoSubmit: true,
-        	maxfields: 2,
-		callback: extendedCombinations.trillian
-	},
 	{
 		combinationId: 'skypeTwoPageAuth',
 		combinationName: 'Skype Two Page Login Procedure',
@@ -1175,7 +1109,6 @@ mcCombinations.prototype.retrieveCredentialsCallback = function (credentials) {
 					currentForm.combination.fields.username.val('');
 					currentForm.combination.fields.username.click();
 					try {
-						currentForm.combination.fields.username.sendkeys( credentials[0].Login );
 						this.triggerChangeEvent(currentForm.combination.fields.username[0], credentials[0].Login)
 					} catch (e) {}					
 					currentForm.combination.fields.username[0].dispatchEvent(new Event('change'));
@@ -1274,7 +1207,8 @@ mcCombinations.prototype.retrieveCredentialsCallback = function (credentials) {
 		'[role="button"]:visible',
 		'a:visible',
 		'input[onclick]:visible',
-		'div[onclick]:visible'
+		'div[onclick]:visible',
+		'div.button'
 	]
 	
 	var submitButton

--- a/chrome_extension/vendor/mooltipass/mcCombinations.js
+++ b/chrome_extension/vendor/mooltipass/mcCombinations.js
@@ -1252,6 +1252,8 @@ mcCombinations.prototype.retrieveCredentialsCallback = function (credentials) {
 		/showpassword/i,
 		/remember_login/i,
 		/sign up/i,
+		/facebook/i,
+		/google/i,
 		/id=".*?search.*?"/i,
 		/id="btnLoadMoreProducts"/i,
 		/id="loginLink"/i,

--- a/chrome_extension/vendor/mooltipass/mcCombinations.js
+++ b/chrome_extension/vendor/mooltipass/mcCombinations.js
@@ -1227,13 +1227,12 @@ mcCombinations.prototype.retrieveCredentialsCallback = function (credentials) {
 	
 	// Selectors are ordered by priority, first ones are more important.
 	BUTTON_SELECTORS = [
-		'td.custom-button-center',
+		'td.custom-button-center:visible',
 		'[type="submit"]:visible, a[href^="javascript:"]:visible',
 		'button:visible',
 		'[role="button"]:visible',
 		'a:visible',
-		'div[onclick]:visible',
-		'div:visible'
+		'div[onclick]:visible'
 	]
 	
 	var submitButton = null

--- a/chrome_extension/vendor/mooltipass/mcCombinations.js
+++ b/chrome_extension/vendor/mooltipass/mcCombinations.js
@@ -1248,7 +1248,7 @@ mcCombinations.prototype.retrieveCredentialsCallback = function (credentials) {
 	],
 	
 	IGNORE_PATTERNS = [
-		/forgotpassword/i,
+		/forgot/i,
 		/lostlogin/i,
 		/showpassword/i,
 		/remember_login/i,

--- a/chrome_extension/vendor/mooltipass/mcCombinations.js
+++ b/chrome_extension/vendor/mooltipass/mcCombinations.js
@@ -267,7 +267,7 @@ function mcCombinations() {}
 mcCombinations.prototype = ( function() {
 	return {
 		constructor:mcCombinations,
-		inputQueryPattern: "input[type='text']:not([class='search']), input[type='email'], input[type='login'], input[type='password']:not(.notinview), input[type='tel'], input[type='number'], input:not([type])",
+		inputQueryPattern: "input[type='text']:not([class='search']), input[type='email'], input[type='login'], input[type='password']:not(.notinview), input[type='tel'], input[type='number'], input:not([type]), input[name='username']",
 		forms: {
 			noform: { fields: [] }
 		},
@@ -422,7 +422,7 @@ mcCombinations.prototype.possibleCombinations = [
 		combinationName: 'Simple Login Form with Text',
 		requiredFields: [
 			{
-				selector: 'input[type=text],input[type=login],input[type=tel],input:not([type])',
+				selector: 'input[type=text],input[type=login],input[type=tel],input:not([type]),input[name=username]',
 				mapsTo: 'username'
 			},
 			{
@@ -1213,6 +1213,7 @@ mcCombinations.prototype.retrieveCredentialsCallback = function (credentials) {
 				var inputs = cipFields.getAllFields();
 				cip.initPasswordGenerator(inputs);
 			}
+			
 			if (currentForm.combination.autoSubmit &&
 				  !this.settings.doNotSubmitAfterFill &&
 				  (!currentForm.combination.fields.username || mpJQ.contains(document, currentForm.combination.fields.username[0])) &&

--- a/chrome_extension/vendor/mooltipass/mcCombinations.js
+++ b/chrome_extension/vendor/mooltipass/mcCombinations.js
@@ -1192,7 +1192,6 @@ mcCombinations.prototype.retrieveCredentialsCallback = function (credentials) {
 		/google/i,
 		/id=".*?search.*?"/i,
 		/id="btnLoadMoreProducts"/i,
-		/id="loginLink"/i,
 		/class=".*?search.*?"/i,
 		/class="login_row"/i,
 		/href=".*?loginpage.*?"/i,

--- a/chrome_extension/vendor/mooltipass/mcCombinations.js
+++ b/chrome_extension/vendor/mooltipass/mcCombinations.js
@@ -614,7 +614,7 @@ mcCombinations.prototype.detectCombination = function() {
 				for (form in this.forms) {
 					var currentForm = this.forms[form]
 					if (currentForm.element) {
-						var field = currentForm.combination.fields.username || currentForm.combination.fields.password,
+						var field = currentForm.combination.fields.password || currentForm.combination.fields.username,
 								submitButton = this.detectSubmitButton(field, field.parent())
 							
 						this.usernameFieldId =
@@ -811,7 +811,7 @@ mcCombinations.prototype.detectForms = function() {
 			}
 			
 			// Handle sumbit event on submit button click or return keydown.
-			var field = currentForm.combination.fields.username || currentForm.combination.fields.password,
+			var field = currentForm.combination.fields.password || currentForm.combination.fields.username,
 					submitButton = this.detectSubmitButton(field, field.parent())
 				
 			this.usernameFieldId =
@@ -1268,7 +1268,7 @@ mcCombinations.prototype.doSubmit = function doSubmit( currentForm ) {
 	if (this.settings.debugLevel > 4) cipDebug.log('%c mcCombinations: %c doSubmit','background-color: #c3c6b4','color: #333333');
 	
 	// Trying to find submit button and trigger click event.
-	var field = currentForm.combination.fields.username || currentForm.combination.fields.password,
+	var field = currentForm.combination.fields.password || currentForm.combination.fields.username,
 			submitButton = this.detectSubmitButton(field, field.parent())
 	
 	if (submitButton) {


### PR DESCRIPTION
* issue with id field with special symbols, password generator didn't show up in this case
* issue when we change fields in selection, but mcCombs still used old ones
* removed trillian extended combination and sendkeys for login (somehow it caused site scripts to clear password field)
* added soundcloud support for 2-step auth
* change how detectSubmitButton works: find buttons near field and go to the top, compare distance based on viewport position
* compare distance between button and password field, not login field