### PR TITLE
github and microspot fixed

### DIFF
--- a/sauce_labs_tests/src/test/java/mooltipass/automatedTest/pageObjects/GitHub.java
+++ b/sauce_labs_tests/src/test/java/mooltipass/automatedTest/pageObjects/GitHub.java
@@ -15,6 +15,7 @@ public class GitHub extends AbstractPage{
 
 	@FindBy(xpath = "//a[@href='/login']")
 	private WebElement loginBtn;
+	
 	@FindBy(id = "login_field")
 	private WebElement email;
 
@@ -28,7 +29,7 @@ public class GitHub extends AbstractPage{
 	@FindBy(xpath = "//form[@class='logout-form']//button[@class='dropdown-item dropdown-signout']")
 	private WebElement logoutBtn;
 	
-	@FindBy(xpath = "//a[@class='header-navlink name tooltipped tooltipped-sw js-menu-target']")
+	@FindBy(xpath = "//details[@class='dropdown-details d-flex pl-2 flex-items-center']")
 	private WebElement dashBoard;
 	
 	public void enterEmail(String value){
@@ -58,8 +59,8 @@ public class GitHub extends AbstractPage{
 	}
 	
 	public boolean checkLogin(){		        
-		waitUntilAppears(By.xpath( "//a[@class='header-navlink name tooltipped tooltipped-sw js-menu-target']"));
-		return isElementPresent(By.xpath( "//a[@class='header-navlink name tooltipped tooltipped-sw js-menu-target']"));
+		waitUntilAppears(By.xpath( "//details[@class='dropdown-details d-flex pl-2 flex-items-center']"));
+		return isElementPresent(By.xpath( "//details[@class='dropdown-details d-flex pl-2 flex-items-center']"));
 	}
 	public boolean checkAtLoginPage(){
 		return isElementPresent(By.id("login_field"));

--- a/sauce_labs_tests/src/test/java/mooltipass/automatedTest/pageObjects/Microspot.java
+++ b/sauce_labs_tests/src/test/java/mooltipass/automatedTest/pageObjects/Microspot.java
@@ -15,24 +15,20 @@ public class Microspot extends AbstractPage{
 		PageFactory.initElements(driver, this);
 	}
 
-	@FindBy(id = "loginForm:emailReg")
+	@FindBy(id = "email")
 	private WebElement email;
 
-	@FindBy(id = "loginForm:passwordReg")
+	@FindBy(id = "password")
 	private WebElement password;
 
-	@FindBy(xpath = "//div[contains(text(),'ANMELDEN')]")
+	@FindBy(xpath = "//button[.//span[contains(text(),'Anmelden')]]")
 	private WebElement submitLogin;
 	
-	/*
-	@FindBy(xpath = "//a[@href='/msp/pages/registration.jsf']")
-	private WebElement loginBtn;
-	 */
 
-	@FindBy(xpath = "//span[@class='headerLoginText']")
+	@FindBy(xpath = "//span[text()='Mein Konto']")
 	private WebElement loginBtn;
 	
-	@FindBy(xpath = "//form[@id='logoutForm']//a[@href='#']")
+	@FindBy(xpath = "//button[.//span[contains(text(),'Abmelden')]]")
 	private WebElement logoutBtn;
 	
 
@@ -64,11 +60,11 @@ public class Microspot extends AbstractPage{
 	}
 	public boolean checkLogin(){
 
-		waitUntilAppears(By.xpath("//a[contains(text(),'Abmelden')]"));
-		return isElementPresent(By.xpath("//a[contains(text(),'Abmelden')]"));
+		waitUntilAppears(By.xpath("//button[.//span[contains(text(),'Abmelden')]]"));
+		return isElementPresent(By.xpath("//button[.//span[contains(text(),'Abmelden')]]"));
 	}
 	public boolean checkAtLoginPage(){
-		return isElementPresent(By.id("loginForm:emailReg"));
+		return isElementPresent(By.id("email"));
 	}
 	
 }

--- a/sauce_labs_tests/src/test/resources/mooltipass/automatedTest/features/Supported.feature
+++ b/sauce_labs_tests/src/test/resources/mooltipass/automatedTest/features/Supported.feature
@@ -154,7 +154,7 @@ Then I should be logged in AliBaba
 Scenario: Testing Microspot
 Given I navigate to 'https://www.microspot.ch/'
 When I go to Microspot login page
-When I login Microspot with 'mooltipasstest@gmail.com'
+When I login Microspot with 'citesting@themooltipass.com'
 Then I should be logged in Microspot
 When I logout Microspot
 When I go to Microspot login page


### PR DESCRIPTION
Fixes #\<GitHub-issue-number\>.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [ ] This PR is compliant with the contributing guidelines (if not, please describe why): code is fully documented and if possible a .md file is made.
- [ ] The PR text includes a **detailed explanation** (more than 50 chars)
- [ ] I have thoroughly tested my contribution.

\<Description of and rational behind this PR\>

**In case of a PR concerning the Mooltipass extension:**  
The following test procedure should be done, in the following order.  
  
1) Recall functionality test (Mooltipass unlocked):  
- visit a website you have credentials for  
- make sure you get prompted by your mooltipass  
- accept the credentials sending request  
- make sure you are logged in  
  
2) Storage functionality test (Mooltipass unlocked):  
- visit a website you don't have credentials for  
- fill the username and password field, submit  
- make sure the mooltipass prompts you for password storage **once**  
- accept the credentials storage request  
- run test 1) to make sure credentials are correctly stored  
  
3) Cancel functionality test (Mooltipass unlocked):  
- visit a website you have credentials for  
- make sure you get prompted by your mooltipass   
- do not accept the credentials sending request, close the tab  
- make sure the prompt gets removed on the mooltipass  
  
4) Credentials requests queue test (Mooltipass **locked**)  
- visit a website you have credentials for  
- unlock your mooltipass  
- make sure you get prompted by your mooltipass   
  
5) Credentials requests queue test (Mooltipass unlocked)  
- visit a website A you have credentials for  
- make sure you get prompted by your mooltipass   
- do not accept the credentials sending request  
- visit a website B you have credentials for  
- close the tab containing the website A  
- make sure the first prompt is cancelled on the mooltipass  
- make sure another prompt for website B is displayed on the mooltipass  
   