### PR TITLE
safari compatibility

### DIFF
--- a/chrome_extension/Mooltipass.safariextension/Info.plist
+++ b/chrome_extension/Mooltipass.safariextension/Info.plist
@@ -5,7 +5,7 @@
 	<key>Author</key>
 	<string>Stephan Electronics</string>
 	<key>Builder Version</key>
-	<string>11602.2.14.0.7</string>
+	<string>12602.4.8</string>
 	<key>CFBundleDisplayName</key>
 	<string>Mooltipass Extension</string>
 	<key>CFBundleIdentifier</key>
@@ -13,9 +13,9 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1</string>
+	<string>1.3</string>
 	<key>CFBundleVersion</key>
-	<string>81</string>
+	<string>1</string>
 	<key>Chrome</key>
 	<dict>
 		<key>Database Quota</key>

--- a/chrome_extension/background/event.js
+++ b/chrome_extension/background/event.js
@@ -109,9 +109,12 @@ mooltipassEvent.onGetSettings = function(callback, tab) {
 	mooltipassEvent.onLoadSettings();
 	var settings = page.settings;
 	
-	settings.status = mooltipass.device._status;
-	settings.tabId = tab.id;
+	settings['status'] = mooltipass.device._status;
+	settings['tabId'] = tab.id;
 	settings['defined-credential-fields'] = settings['defined-credential-fields'] || {}
+	settings['extension-base'] = isSafari
+		?	safari.extension.baseURI
+		: chrome.extension.getURL('/')
 	
 	callback({ data: settings }, tab );
 }

--- a/chrome_extension/background/init.js
+++ b/chrome_extension/background/init.js
@@ -40,16 +40,11 @@ startMooltipass = function() {
 	if ( isSafari ) {
 		safari.application.addEventListener( "message", mooltipassEvent.onMessage, false );
 
-		safari.application.addEventListener("open", function(tab) {
-			// TODO: Gaston, this can be removed
-		}, true);
-
 		safari.application.addEventListener("activate", function( evt ) {
 			page.currentTabId = evt.target.activeTab;
 		}, true);
 	} else {
 		chrome.runtime.onMessage.addListener( mooltipassEvent.onMessage );
-
 
 		chrome.tabs.onCreated.addListener(function(tab) {
 			if(tab.id > 0) {

--- a/chrome_extension/mooltipass-content.js
+++ b/chrome_extension/mooltipass-content.js
@@ -177,10 +177,11 @@ cipPassword.createIcon = function(field) {
 	$zIndex += 1;
 
 	var iframe = document.createElement('iframe');
-	iframe.src = chrome.extension.getURL('ui/password-dialog-toggle/password-dialog-toggle.html') + '?' +
+	iframe.src = cip.settings['extension-base'] + 'ui/password-dialog-toggle/password-dialog-toggle.html?' +
 		encodeURIComponent(JSON.stringify({
 			type: $size == 16 ? 'small' : 'big',
-			iconId: PREFIX + '-' + field.data('mp-id')
+			iconId: PREFIX + '-' + field.data('mp-id'),
+			settings: cip.settings
 		}));
 	
 	var $icon = $(iframe)
@@ -311,7 +312,7 @@ cipDefine.show = function() {
 	iframe.onload = function() {
 		$(iframe).fadeIn(100)
 	}
-	iframe.src = chrome.extension.getURL('ui/custom-credentials-selection/custom-credentials-selection.html') + '?' +
+	iframe.src = cip.settings['extension-base'] + 'ui/custom-credentials-selection/custom-credentials-selection.html?' +
 		encodeURIComponent(JSON.stringify({
 			settings: cip.settings,
 			origin: document.location.origin
@@ -1677,7 +1678,7 @@ var mpDialog = {
 		iframe.onload = function() {
 			$(iframe).fadeIn(100)
 		}
-		iframe.src = chrome.extension.getURL('ui/password-dialog/password-dialog.html') + '?' +
+		iframe.src = cip.settings['extension-base'] + 'ui/password-dialog/password-dialog.html?' +
 			encodeURIComponent(JSON.stringify({
 				login: mcCombs.credentialsCache && mcCombs.credentialsCache.length && mcCombs.credentialsCache[0].Login
 							 ? mcCombs.credentialsCache[0].Login

--- a/chrome_extension/ui/custom-credentials-selection/custom-credentials-selection.html
+++ b/chrome_extension/ui/custom-credentials-selection/custom-credentials-selection.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<link rel="stylesheet" href="/ui/vendor/foundation/foundation.min.css">
+	<link rel="stylesheet" href="../vendor/foundation/foundation.min.css">
 	<link rel="stylesheet" href="custom-credentials-selection.css">
 
-	<script src="/vendor/jquery-3.2.1.js"></script>
-	<script src="/vendor/jquery-ui-1.11.4.custom/jquery-ui.js"></script>
+	<script src="../../vendor/jquery-3.2.1.js"></script>
+	<script src="../../vendor/jquery-ui-1.11.4.custom/jquery-ui.js"></script>
 	<script src="custom-credentials-selection.js"></script>
 </head>
 

--- a/chrome_extension/ui/http-auth/http-auth.html
+++ b/chrome_extension/ui/http-auth/http-auth.html
@@ -1,16 +1,16 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <link rel="stylesheet" href="/mooltipass-content.css">
-  <link rel="stylesheet" href="/ui/vendor/foundation/foundation.min.css">
+  <link rel="stylesheet" href="../../mooltipass-content.css">
+  <link rel="stylesheet" href="../vendor/foundation/foundation.min.css">
   <link rel="stylesheet" href="http-auth.css">
 
-  <script src="/vendor/jquery-3.2.1.js"></script>
-  <script src="/vendor/mooltipass/website.js"></script>
-  <script src="/vendor/jquery-ui-1.11.4.custom/jquery-ui.js"></script>
-  <script src="/vendor/sendkeys.js"></script>
-  <script src="/vendor/mooltipass/mcCombinations.js"></script>
-  <script src="/mooltipass-content.js"></script>
+  <script src="../../vendor/jquery-3.2.1.js"></script>
+  <script src="../../vendor/mooltipass/website.js"></script>
+  <script src="../../vendor/jquery-ui-1.11.4.custom/jquery-ui.js"></script>
+  <script src="../../vendor/sendkeys.js"></script>
+  <script src="../../vendor/mooltipass/mcCombinations.js"></script>
+  <script src="../../mooltipass-content.js"></script>
   <script src="http-auth.js"></script>
 </head>
 

--- a/chrome_extension/ui/password-dialog-toggle/password-dialog-toggle.css
+++ b/chrome_extension/ui/password-dialog-toggle/password-dialog-toggle.css
@@ -5,7 +5,6 @@ body {
 .icon {
 	cursor: pointer;
 	background-size: contain;
-	background-image: url(chrome-extension://__MSG_@@extension_id__/images/icon_password_128.png);
 }
 
 .icon__small {
@@ -16,11 +15,3 @@ body {
 .icon__big {
 	width: 24px;
 	height: 24px;
-	background-image: url(chrome-extension://__MSG_@@extension_id__/images/icon_password_128.png);
-}
-
-@-moz-document url-prefix() { 
-	.icon {
-    background-image: url(/images/icon_password_128.png);
-	}
-}

--- a/chrome_extension/ui/password-dialog-toggle/password-dialog-toggle.html
+++ b/chrome_extension/ui/password-dialog-toggle/password-dialog-toggle.html
@@ -3,7 +3,7 @@
 <head>
   <link rel="stylesheet" href="password-dialog-toggle.css">
 	
-  <script src="/vendor/jquery-3.2.1.js"></script>
+  <script src="../../vendor/jquery-3.2.1.js"></script>
   <script src="password-dialog-toggle.js"></script>
 </head>
 

--- a/chrome_extension/ui/password-dialog-toggle/password-dialog-toggle.js
+++ b/chrome_extension/ui/password-dialog-toggle/password-dialog-toggle.js
@@ -3,22 +3,25 @@
  * 
  * @param type (small | big) {String}
  * @param target {jQuery object} iFrame element
+ * @param settings {Object}
  */
 
 window.data = JSON.parse(decodeURIComponent(window.location.search.slice(1)))
 
 $(function() {
-	$('.icon').addClass('icon__' + data.type)
-	$('.icon').on('click', function() {
-		messaging({
-			action: 'create_action',
-			args: [{
-				action: 'password_dialog_toggle_click',
-				args: {
-					iconId: data.iconId
-				}
-			}]
-		});
+	$('.icon')
+		.addClass('icon__' + data.type)
+		.css('background-image', 'url(' + data.settings['extension-base'] + 'images/icon_password_128.png)')
+		.on('click', function() {
+			messaging({
+				action: 'create_action',
+				args: [{
+					action: 'password_dialog_toggle_click',
+					args: {
+						iconId: data.iconId
+					}
+				}]
+			});
 	});
 });
 

--- a/chrome_extension/ui/password-dialog/password-dialog.html
+++ b/chrome_extension/ui/password-dialog/password-dialog.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<link rel="stylesheet" href="/ui/vendor/foundation/foundation.min.css">
+	<link rel="stylesheet" href="../vendor/foundation/foundation.min.css">
 	<link rel="stylesheet" href="password-dialog.css">
 
-	<script src="/vendor/jquery-3.2.1.js"></script>
+	<script src="../../vendor/jquery-3.2.1.js"></script>
 	<script src="password-dialog.js"></script>
 </head>
 

--- a/chrome_extension/updateSafariExtension.sh
+++ b/chrome_extension/updateSafariExtension.sh
@@ -14,7 +14,7 @@ cp -Rf fonts Mooltipass.safariextension/
 cp -Rf ui Mooltipass.safariextension/
 
 # Fixes image paths for content styles
-find ./Mooltipass.safariextension -name "*.css" -type f -print0 | xargs -0 sed -i '' 's/chrome-extension:\/\/__MSG_@@extension_id__\/images/images/g'
+find ./Mooltipass.safariextension -name "*.css" -type f -print0 | xargs -0 sed -i '' 's/chrome-extension:\/\/__MSG_@@extension_id__\/images/\/images/g'
 
 python updateSafariVersion.py
 


### PR DESCRIPTION
Fixed issue with unsupported `getURL` method in Safari and problems with relative paths in UI. And we can't prevent default HTTP Auth process, it's just not supported in Safari.