### PR TITLE
pass mozilla validation

### DIFF
--- a/chrome_extension/manifest.json
+++ b/chrome_extension/manifest.json
@@ -66,7 +66,6 @@
     "https://*/*",
     "http://*/*",
     "https://raw.github.com/",
-    "contentSettings",
     "management",
     "notifications"
   ]


### PR DESCRIPTION
I have removed `contentSettings` permission. It's valid in Chrome, but we don't use this API anyway. For jQuery it seems to be a mistake with hash on testers side, I got exactly the same checksum that supposed to be valid:
```
➜  chrome_extension git:(master) shasum -a 256 vendor/jquery-3.2.1.js
0d9027289ffa5d9f6c8b4e0782bb31bbff2cef5ee3708ccbcb7a22df9128bb21  vendor/jquery-3.2.1.js
```