### PR TITLE
support tab focus and close event in Safari

### DIFF
--- a/chrome_extension/background/browserAction.js
+++ b/chrome_extension/background/browserAction.js
@@ -75,7 +75,7 @@ browserAction.showDefault = function(callback, tab) {
         stackData.popup = "popup_login.html";
     }
 
-    if ( tab.id != 'safari' ) { 
+    if (!isSafari) { 
     	browserAction.stackUnshift(stackData, tab.id); 
     	browserAction.show(null, tab);
     }

--- a/chrome_extension/background/event.js
+++ b/chrome_extension/background/event.js
@@ -11,6 +11,20 @@ function messaging( message, tab, callback ) {
 	} else chrome.tabs.sendMessage( typeof(tab) == 'number'?tab:tab.id, message, function(response) {});
 };
 
+/*
+ * Get tabId for Safari.
+ * 
+ * @param tab {Object}
+ * @return tabId {Integer}
+ */
+function getSafariTabId(tab) {
+	for (var i = 0; i < safari.application.activeBrowserWindow.tabs.length; i++) {
+		if (safari.application.activeBrowserWindow.tabs[i] == tab) {
+			return i
+		}
+	}
+}
+
 function cross_notification( notificationId, options ) {
 	if ( isSafari ) {
 		options.tag = notificationId;
@@ -80,7 +94,7 @@ mooltipassEvent.invoke = function(handler, callback, senderTab, args, secondTime
 	if (background_debug_msg > 4) mpDebug.log('%c mooltipassEvent: invoke ', mpDebug.css('e2eef9'), arguments);
 	if ( typeof(senderTab) == 'number' ) senderTab = { id: senderTab };
 
-	if ( senderTab && senderTab.id && !page.tabs[senderTab.id]) {
+	if ( senderTab && senderTab.id != undefined && !page.tabs[senderTab.id]) {
 		page.createTabEntry( senderTab.id );
 	};
 

--- a/chrome_extension/background/page.js
+++ b/chrome_extension/background/page.js
@@ -95,8 +95,10 @@ page.cacheRetrieve = function( callback, tab, arguments ) {
 }
 
 page.initOpenedTabs = function() {
-	if ( isSafari ) { // Safari doesn't use tab ids, just create one placeholder
-		page.createTabEntry('safari');
+	if (isSafari) {
+		for (var i = 0; i < safari.application.activeBrowserWindow.tabs.length; i++) {
+			page.createTabEntry(i)
+		}
 	} else {
 		chrome.tabs.query({}, function(tabs) {
 			for(var i = 0; i < tabs.length; i++) {
@@ -117,7 +119,7 @@ page.switchTab = function(callback, tab) {
 	if (background_debug_msg > 4) mpDebug.log('%c page: %c switchTab ', mpDebug.css('ffeef9'), tab );
 	browserAction.showDefault(null, tab);
 
-	chrome.tabs.sendMessage(tab.id, {action: "activated_tab"});
+	messaging({ action: 'activated_tab' }, tab)
 }
 
 page.setAllLoaded = function( callback, tab ) {

--- a/chrome_extension/popups/js/popup_status.js
+++ b/chrome_extension/popups/js/popup_status.js
@@ -142,7 +142,7 @@ function updateStatusInfo() {
     if( isSafari ) {
         if ( safari.extension.globalPage && safari.extension.globalPage.contentWindow.mooltipassEvent) {
             safari.extension.globalPage.contentWindow.mooltipassEvent.onGetStatus(getStatusCallback, {
-                id: 'safari',
+                id: getSafariTabId(safari.application.activeBrowserWindow.activeTab)
                 url: safari.application.activeBrowserWindow.activeTab.url
             });
         }

--- a/chrome_extension/vendor/mooltipass/device.js
+++ b/chrome_extension/vendor/mooltipass/device.js
@@ -321,8 +321,7 @@ mooltipass.device.sendCredentialRequestMessageFromQueue = function()
                 setTimeout(function()
                 {
                     try {
-                        mooltipass.device.retrieveCredentialsQueue[0].callback(credentials,
-                          mooltipass.device.retrieveCredentialsQueue[0].tabid == 'safari'?mooltipass.device.retrieveCredentialsQueue[0].tab:mooltipass.device.retrieveCredentialsQueue[0].tabid );
+                        mooltipass.device.retrieveCredentialsQueue[0].callback(credentials, mooltipass.device.retrieveCredentialsQueue[0].tab);
                     } catch(err) {}
                     
                     // Treat other pending requests
@@ -611,11 +610,6 @@ mooltipass.device.retrieveCredentials = function(callback, tab, url, submiturl, 
 {
     if (background_debug_msg > 3) mpDebug.log('%c device: %c retrieveCredentials ','background-color: #e244ff','color: #484848', arguments);
 
-    if (!tab.hasOwnProperty('id')) tab.id = 'safari';
-
-    // unset error message
-    //page.tabs[tab.id].errorMessage = null;
-
     // parse url and check if it is valid and not blacklisted
     var parsed_url = mooltipass.backend.extractDomainAndSubdomain(submiturl);
     if(!parsed_url.valid)
@@ -763,7 +757,7 @@ mooltipass.device.messageListener = function(message, sender, sendResponse) {
                     Password: message.credentials.password,
                     StringFields: []
                 }
-            ], mooltipass.device.retrieveCredentialsQueue[0].tabid == 'safari'?mooltipass.device.retrieveCredentialsQueue[0].tab:mooltipass.device.retrieveCredentialsQueue[0].tabid );
+            ], mooltipass.device.retrieveCredentialsQueue[0].tab);
         }
         catch(err)
         {


### PR DESCRIPTION
Test scenario for tab closing:
1. Open page with saved credentials
2. See notification on the device
3. Close tab
4. Notification should disappear on the device

Test scenario for tab focusing:
1. Open page with saved credentials
2. Move to another tab
3. Move back
4. Notification should appear on the device