### PR TITLE
hide custom credentials for two page auth

### DIFF
--- a/chrome_extension/mooltipass-content.js
+++ b/chrome_extension/mooltipass-content.js
@@ -175,7 +175,7 @@ cipPassword.createIcon = function(field) {
 		$zIndex = 1;
 	}
 	$zIndex += 1;
-
+	
 	var iframe = document.createElement('iframe');
 	iframe.src = cip.settings['extension-base'] + 'ui/password-dialog-toggle/password-dialog-toggle.html?' +
 		encodeURIComponent(JSON.stringify({
@@ -1687,7 +1687,10 @@ var mpDialog = {
 				offsetTop: target.offset().top - $(window).scrollTop() + target.height() / 2 - 20,
 				isPasswordOnly: isPasswordOnly,
 				windowWidth: window.innerWidth,
-				windowHeight: window.innerHeight
+				windowHeight: window.innerHeight,
+				hideCustomCredentials: mcCombs.possibleCombinations.some(combination =>
+					combination.requiredUrl == window.location.hostname
+				)
 			}));
 			
 		$(iframe).addClass('mp-ui-password-dialog').hide()
@@ -1728,8 +1731,8 @@ var mpDialog = {
 			var usernameFieldId = cipDefine.selection.username || mcCombs.usernameFieldId,
 					passwordFieldId = cipDefine.selection.password || mcCombs.passwordFieldId
 					
-			$('[data-mp-id=' + usernameFieldId + ']').addClass('mp-hover-username')
-			$('[data-mp-id=' + passwordFieldId + ']').addClass('mp-hover-password')
+			usernameFieldId && $('[data-mp-id=' + usernameFieldId + ']').addClass('mp-hover-username')
+			passwordFieldId && $('[data-mp-id=' + passwordFieldId + ']').addClass('mp-hover-password')
 		} else {
 			mpJQ(".mp-hover-username").removeClass("mp-hover-username");
 			mpJQ(".mp-hover-password").removeClass("mp-hover-password");

--- a/chrome_extension/ui/password-dialog/password-dialog.js
+++ b/chrome_extension/ui/password-dialog/password-dialog.js
@@ -7,6 +7,7 @@
  * @param isPasswordOnly {Boolean}
  * @param windowWidth {Number}
  * @param windowHeight {Number}
+ * @param hideCustomCredentials {Boolean}
  */
  
 window.data = JSON.parse(decodeURIComponent(window.location.search.slice(1)))
@@ -139,6 +140,10 @@ $(function() {
 		// Move Arrows to the right place
 		if ( exceedingBottom > 0 ) mpBox.find('.mp-triangle-in, .mp-triangle-out').css({ top: 8 + exceedingBottom + 'px' });
     
+		if (data.hideCustomCredentials) {
+			mpBox.find('.mooltipass-select-custom').hide()
+		}
+		
     if (data.isPasswordOnly) {
   		mpBox.find('.mp-first').removeClass('mp-first');
   		mpBox.find('.login-area').addClass('mp-first').show();

--- a/chrome_extension/vendor/mooltipass/mcCombinations.js
+++ b/chrome_extension/vendor/mooltipass/mcCombinations.js
@@ -605,6 +605,12 @@ mcCombinations.prototype.detectCombination = function() {
 	if (this.settings.debugLevel > 4) cipDebug.log('%c mcCombinations: %c detectCombination','background-color: #c3c6b4','color: #333333');
 	var numberOfFields = this.getAllForms();
 	if (this.settings.debugLevel > 1) cipDebug.log('detectCombination has found ' + numberOfFields + ' fields.');
+	
+	// Init the password generator as always.
+	if ( mcCombs.settings.usePasswordGenerator ) {
+		var inputs = cipFields.getAllFields();
+		cip.initPasswordGenerator(inputs);
+	}
 
 	if ( numberOfFields > 0 ) {
 		// Check for special cases first 
@@ -837,12 +843,6 @@ mcCombinations.prototype.detectForms = function() {
 					if (event.which == 13) { this.onSubmit.call(this, { target: currentForm.element && currentForm.element[0] }) }
 				}.bind(this, currentForm))
 		}
-	}
-
-	// Init the password generator as always
-	if ( mcCombs.settings.usePasswordGenerator ) {
-		var inputs = cipFields.getAllFields();
-		cip.initPasswordGenerator(inputs);
 	}
 
 	// If there are no combinations detected, init the old method as well.


### PR DESCRIPTION
Open _skype.com, soundcloud.com, google.com, etc_ services with two page auth and discover that `Select custom credential fields` isn't available in password dialog.