### PR TITLE
reenable notifications when device is connected

### DIFF
--- a/chrome_extension/vendor/mooltipass/device.js
+++ b/chrome_extension/vendor/mooltipass/device.js
@@ -691,6 +691,10 @@ mooltipass.device.messageListener = function(message, sender, sendResponse) {
     if ( typeof( message.noCredentials ) === "undefined" ) message.noCredentials = null;
     if ( typeof( message.updateComplete ) === "undefined" ) message.updateComplete = null;
     
+    // Reenable notifications when device status changes.
+    if (mooltipass.device._status.connected != message.deviceStatus.connected) {
+      mooltipass.backend.disableNonUnlockedNotifications = false;
+    }
     
     //console.log('messageListener:', message );
     // Returned on a PING, contains the status of the device
@@ -708,8 +712,7 @@ mooltipass.device.messageListener = function(message, sender, sendResponse) {
         };
         if (!message.deviceStatus.connected)
         {
-                mooltipass.device.retrieveCredentialsQueue = [];            
-                mooltipass.backend.disableNonUnlockedNotifications = false;
+                mooltipass.device.retrieveCredentialsQueue = [];
         }
         else
         {

--- a/chrome_extension/vendor/mooltipass/device.js
+++ b/chrome_extension/vendor/mooltipass/device.js
@@ -709,6 +709,7 @@ mooltipass.device.messageListener = function(message, sender, sendResponse) {
         if (!message.deviceStatus.connected)
         {
                 mooltipass.device.retrieveCredentialsQueue = [];            
+                mooltipass.backend.disableNonUnlockedNotifications = false;
         }
         else
         {


### PR DESCRIPTION
1. Connect locked device
2. Refresh page in browser
3. See that notification shows up
4. Refresh page again
5. See that notification doesn't show up
6. Reconnect device
7. Refresh page
8. See that notification shows up