### PR TITLE
fixed failing websites

### DIFF
--- a/sauce_labs_tests/src/test/java/mooltipass/automatedTest/pageObjects/EBay.java
+++ b/sauce_labs_tests/src/test/java/mooltipass/automatedTest/pageObjects/EBay.java
@@ -31,8 +31,9 @@ public class EBay extends AbstractPage{
 	private WebElement submitLogin;
 	
 
-	@FindBy(xpath = "//a[@class='gh-ua gh-control']")
+	@FindBy(xpath = "//button[@class='gh-ua gh-control']")
 	private WebElement dashBoard;
+		
 	@FindBy(xpath = "//a[@href='https://signin.ebay.com/ws/eBayISAPI.dll?SignIn&lgout=1']")
 	private WebElement logoutBtn;
 	
@@ -67,8 +68,8 @@ public class EBay extends AbstractPage{
 	
 	public boolean checkLogin(){
 
-		waitUntilAppears(By.xpath("//a[@class='gh-ua gh-control']"));
-		return isElementPresent(By.xpath("//a[@class='gh-ua gh-control']"));
+		waitUntilAppears(By.xpath("//button[@class='gh-ua gh-control']"));
+		return isElementPresent(By.xpath("//button[@class='gh-ua gh-control']"));
 	}
 	public boolean checkAtLoginPage(){
 		//waitUntilAppears(By.id("sgnBt"));

--- a/sauce_labs_tests/src/test/java/mooltipass/automatedTest/pageObjects/GitHub.java
+++ b/sauce_labs_tests/src/test/java/mooltipass/automatedTest/pageObjects/GitHub.java
@@ -28,8 +28,8 @@ public class GitHub extends AbstractPage{
 	
 	@FindBy(xpath = "//form[@class='logout-form']//button[@class='dropdown-item dropdown-signout']")
 	private WebElement logoutBtn;
-	
-	@FindBy(xpath = "//details[@class='dropdown-details d-flex pl-2 flex-items-center']")
+							
+	@FindBy(xpath = "//details[contains(@class,'dropdown-details d-flex pl-2 flex-items-center')]")
 	private WebElement dashBoard;
 	
 	public void enterEmail(String value){
@@ -59,8 +59,8 @@ public class GitHub extends AbstractPage{
 	}
 	
 	public boolean checkLogin(){		        
-		waitUntilAppears(By.xpath( "//details[@class='dropdown-details d-flex pl-2 flex-items-center']"));
-		return isElementPresent(By.xpath( "//details[@class='dropdown-details d-flex pl-2 flex-items-center']"));
+		waitUntilAppears(By.xpath( "//details[contains(@class,'dropdown-details d-flex pl-2 flex-items-center')]"));
+		return isElementPresent(By.xpath( "//details[contains(@class,'dropdown-details d-flex pl-2 flex-items-center')]"));
 	}
 	public boolean checkAtLoginPage(){
 		return isElementPresent(By.id("login_field"));


### PR DESCRIPTION
Fixes #\<GitHub-issue-number\>.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [ ] This PR is compliant with the contributing guidelines (if not, please describe why): code is fully documented and if possible a .md file is made.
- [ ] The PR text includes a **detailed explanation** (more than 50 chars)
- [ ] I have thoroughly tested my contribution.

\<Description of and rational behind this PR\>

**In case of a PR concerning the Mooltipass extension:**  
The following test procedure should be done, in the following order.  
  
1) Recall functionality test (Mooltipass unlocked):  
- visit a website you have credentials for  
- make sure you get prompted by your mooltipass  
- accept the credentials sending request  
- make sure you are logged in  
  
2) Storage functionality test (Mooltipass unlocked):  
- visit a website you don't have credentials for  
- fill the username and password field, submit  
- make sure the mooltipass prompts you for password storage **once**  
- accept the credentials storage request  
- run test 1) to make sure credentials are correctly stored  
  
3) Cancel functionality test (Mooltipass unlocked):  
- visit a website you have credentials for  
- make sure you get prompted by your mooltipass   
- do not accept the credentials sending request, close the tab  
- make sure the prompt gets removed on the mooltipass  
  
4) Credentials requests queue test (Mooltipass **locked**)  
- visit a website you have credentials for  
- unlock your mooltipass  
- make sure you get prompted by your mooltipass   
  
5) Credentials requests queue test (Mooltipass unlocked)  
- visit a website A you have credentials for  
- make sure you get prompted by your mooltipass   
- do not accept the credentials sending request  
- visit a website B you have credentials for  
- close the tab containing the website A  
- make sure the first prompt is cancelled on the mooltipass  
- make sure another prompt for website B is displayed on the mooltipass  
   