### PR TITLE
updated Ricardo pageobjects class

### DIFF
--- a/sauce_labs_tests/src/test/java/mooltipass/automatedTest/pageObjects/Ricardo.java
+++ b/sauce_labs_tests/src/test/java/mooltipass/automatedTest/pageObjects/Ricardo.java
@@ -13,21 +13,23 @@ public class Ricardo extends AbstractPage{
 		PageFactory.initElements(driver, this);
 	}
 
-	@FindBy(xpath = "//li/*[contains(text(),'Einloggen')]")
+	@FindBy(xpath = "//span[text()='Anmelden']")
 	private WebElement loginBtn;
 
-	@FindBy(xpath = "//section[@id='it_LoginSection']//input[@type='text']")
+	@FindBy(xpath = "//input[@type='text']")
 	private WebElement email;
 
 	@FindBy(xpath = "//input[@type='password']")
 	private WebElement password;
 
-	@FindBy(xpath = "//button[@id='modalsubmit']")
+	@FindBy(xpath = "//input[@type='submit']")
 	private WebElement submitLogin;
 	
-	@FindBy(id = "hd-logout")
+	@FindBy(xpath = "//a[text()='Abmelden']")
 	private WebElement logoutBtn;
 	
+	@FindBy(id = "user-menu")
+	private WebElement menuBtn;
 	
 	public void goToLogin(){
 		waitUntilAppears(loginBtn);
@@ -55,8 +57,8 @@ public class Ricardo extends AbstractPage{
 	
 	public boolean checkLogin(){
 
-		waitUntilAppears(By.id("hd-logout"));
-		return isElementPresent(By.id("hd-logout"));
+		waitUntilAppears(By.id("user-menu"));
+		return isElementPresent(By.id("user-menu"));
 	}
 
 
@@ -65,6 +67,8 @@ public class Ricardo extends AbstractPage{
 	}
 	
 	public void logout(){
+		menuBtn.click();
+		waitUntilAppears(logoutBtn);
 		logoutBtn.click();
 
 	}


### PR DESCRIPTION
Fixes #\<GitHub-issue-number\>.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [ ] This PR is compliant with the contributing guidelines (if not, please describe why): code is fully documented and if possible a .md file is made.
- [ ] The PR text includes a **detailed explanation** (more than 50 chars)
- [ ] I have thoroughly tested my contribution.

\<Description of and rational behind this PR\>

**In case of a PR concerning the Mooltipass extension:**  
The following test procedure should be done, in the following order.  
  
1) Recall functionality test (Mooltipass unlocked):  
- visit a website you have credentials for  
- make sure you get prompted by your mooltipass  
- accept the credentials sending request  
- make sure you are logged in  
  
2) Storage functionality test (Mooltipass unlocked):  
- visit a website you don't have credentials for  
- fill the username and password field, submit  
- make sure the mooltipass prompts you for password storage **once**  
- accept the credentials storage request  
- run test 1) to make sure credentials are correctly stored  
  
3) Cancel functionality test (Mooltipass unlocked):  
- visit a website you have credentials for  
- make sure you get prompted by your mooltipass   
- do not accept the credentials sending request, close the tab  
- make sure the prompt gets removed on the mooltipass  
  
4) Credentials requests queue test (Mooltipass **locked**)  
- visit a website you have credentials for  
- unlock your mooltipass  
- make sure you get prompted by your mooltipass   
  
5) Credentials requests queue test (Mooltipass unlocked)  
- visit a website A you have credentials for  
- make sure you get prompted by your mooltipass   
- do not accept the credentials sending request  
- visit a website B you have credentials for  
- close the tab containing the website A  
- make sure the first prompt is cancelled on the mooltipass  
- make sure another prompt for website B is displayed on the mooltipass  
   