### PR TITLE
microspot, turkish airlines and ebay fixes of tests

### DIFF
--- a/sauce_labs_tests/src/test/java/mooltipass/automatedTest/pageObjects/EBay.java
+++ b/sauce_labs_tests/src/test/java/mooltipass/automatedTest/pageObjects/EBay.java
@@ -37,6 +37,10 @@ public class EBay extends AbstractPage{
 	@FindBy(xpath = "//a[@href='https://signin.ebay.com/ws/eBayISAPI.dll?SignIn&lgout=1']")
 	private WebElement logoutBtn;
 	
+	@FindBy(xpath = "//a[text()='Maybe later']")
+	private WebElement maybeLaterBtn;
+	
+	
 	public void enterEmail(String value){
 		waitUntilAppears(email);
 		email.sendKeys(value);
@@ -67,7 +71,8 @@ public class EBay extends AbstractPage{
 	}
 	
 	public boolean checkLogin(){
-
+		if(waitUntilAppears(maybeLaterBtn))
+				maybeLaterBtn.click();
 		waitUntilAppears(By.xpath("//button[@class='gh-ua gh-control']"));
 		return isElementPresent(By.xpath("//button[@class='gh-ua gh-control']"));
 	}

--- a/sauce_labs_tests/src/test/java/mooltipass/automatedTest/pageObjects/Microspot.java
+++ b/sauce_labs_tests/src/test/java/mooltipass/automatedTest/pageObjects/Microspot.java
@@ -59,7 +59,7 @@ public class Microspot extends AbstractPage{
 	public void logout(){
 		waitUntilAppears(logoutBtn);
 		logoutBtn.click();
-		sleep(3000);
+		sleep(7000);
 	}
 	public boolean checkLogin(){
 

--- a/sauce_labs_tests/src/test/java/mooltipass/automatedTest/pageObjects/TurkishAirlines.java
+++ b/sauce_labs_tests/src/test/java/mooltipass/automatedTest/pageObjects/TurkishAirlines.java
@@ -38,6 +38,7 @@ public class TurkishAirlines extends AbstractPage{
 	}
 	
 	public void goToLogin(){
+		sleep(6000);
 		waitUntilAppears(loginBtn);
 		loginBtn.click();
 	}


### PR DESCRIPTION
Fixes #\<GitHub-issue-number\>.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [ ] This PR is compliant with the contributing guidelines (if not, please describe why): code is fully documented and if possible a .md file is made.
- [ ] The PR text includes a **detailed explanation** (more than 50 chars)
- [ ] I have thoroughly tested my contribution.

\<Description of and rational behind this PR\>

**In case of a PR concerning the Mooltipass extension:**  
The following test procedure should be done, in the following order.  
  
1) Recall functionality test (Mooltipass unlocked):  
- visit a website you have credentials for  
- make sure you get prompted by your mooltipass  
- accept the credentials sending request  
- make sure you are logged in  
  
2) Storage functionality test (Mooltipass unlocked):  
- visit a website you don't have credentials for  
- fill the username and password field, submit  
- make sure the mooltipass prompts you for password storage **once**  
- accept the credentials storage request  
- run test 1) to make sure credentials are correctly stored  
  
3) Cancel functionality test (Mooltipass unlocked):  
- visit a website you have credentials for  
- make sure you get prompted by your mooltipass   
- do not accept the credentials sending request, close the tab  
- make sure the prompt gets removed on the mooltipass  
  
4) Credentials requests queue test (Mooltipass **locked**)  
- visit a website you have credentials for  
- unlock your mooltipass  
- make sure you get prompted by your mooltipass   
  
5) Credentials requests queue test (Mooltipass unlocked)  
- visit a website A you have credentials for  
- make sure you get prompted by your mooltipass   
- do not accept the credentials sending request  
- visit a website B you have credentials for  
- close the tab containing the website A  
- make sure the first prompt is cancelled on the mooltipass  
- make sure another prompt for website B is displayed on the mooltipass  
   