### PR TITLE
fixed pcb, turkishairlines and microspot tests

### DIFF
--- a/sauce_labs_tests/src/test/java/mooltipass/automatedTest/pageObjects/Microspot.java
+++ b/sauce_labs_tests/src/test/java/mooltipass/automatedTest/pageObjects/Microspot.java
@@ -59,7 +59,7 @@ public class Microspot extends AbstractPage{
 	public void logout(){
 		waitUntilAppears(logoutBtn);
 		logoutBtn.click();
-		sleep(7000);
+		sleep(10000);
 	}
 	public boolean checkLogin(){
 

--- a/sauce_labs_tests/src/test/java/mooltipass/automatedTest/pageObjects/PcbWay.java
+++ b/sauce_labs_tests/src/test/java/mooltipass/automatedTest/pageObjects/PcbWay.java
@@ -3,6 +3,7 @@ package mooltipass.automatedTest.pageObjects;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
@@ -31,16 +32,16 @@ public class PcbWay extends AbstractPage{
 	@FindBy(xpath = "//div[@class='nav-ubox']")
 	private WebElement dashBoard;
 	
-	@FindBy(xpath = "//div[@class='olark-top-bar-button']")
+	@FindBy(xpath = "//div[@class='olark-top-bar-button' and @aria-hidden='true']")
 	private WebElement popup;
+	
 	
 	public void goToLogin(){	
 		loginBtn.click();
 	}
 	
 	public void enterEmail(String value){
-		if(isElementPresent(By.xpath("//div[@class='olark-top-bar-button']")) && popup.isDisplayed())
-			popup.click();
+		waitUntilAppears(email);
 		email.sendKeys(value);
 	}
 
@@ -51,8 +52,12 @@ public class PcbWay extends AbstractPage{
 
 	
 	public void submit(){
-
+		try {
 		submitLogin.click();
+		}catch(WebDriverException e) {
+			popup.click();
+			submitLogin.click();
+		}
 	}
 
 	public void logout(){	

--- a/sauce_labs_tests/src/test/java/mooltipass/automatedTest/pageObjects/TurkishAirlines.java
+++ b/sauce_labs_tests/src/test/java/mooltipass/automatedTest/pageObjects/TurkishAirlines.java
@@ -38,7 +38,7 @@ public class TurkishAirlines extends AbstractPage{
 	}
 	
 	public void goToLogin(){
-		sleep(6000);
+		sleep(10000);
 		waitUntilAppears(loginBtn);
 		loginBtn.click();
 	}


### PR DESCRIPTION
Fixes #\<GitHub-issue-number\>.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [ ] This PR is compliant with the contributing guidelines (if not, please describe why): code is fully documented and if possible a .md file is made.
- [ ] The PR text includes a **detailed explanation** (more than 50 chars)
- [ ] I have thoroughly tested my contribution.

\<Description of and rational behind this PR\>

**In case of a PR concerning the Mooltipass extension:**  
The following test procedure should be done, in the following order.  
  
1) Recall functionality test (Mooltipass unlocked):  
- visit a website you have credentials for  
- make sure you get prompted by your mooltipass  
- accept the credentials sending request  
- make sure you are logged in  
  
2) Storage functionality test (Mooltipass unlocked):  
- visit a website you don't have credentials for  
- fill the username and password field, submit  
- make sure the mooltipass prompts you for password storage **once**  
- accept the credentials storage request  
- run test 1) to make sure credentials are correctly stored  
  
3) Cancel functionality test (Mooltipass unlocked):  
- visit a website you have credentials for  
- make sure you get prompted by your mooltipass   
- do not accept the credentials sending request, close the tab  
- make sure the prompt gets removed on the mooltipass  
  
4) Credentials requests queue test (Mooltipass **locked**)  
- visit a website you have credentials for  
- unlock your mooltipass  
- make sure you get prompted by your mooltipass   
  
5) Credentials requests queue test (Mooltipass unlocked)  
- visit a website A you have credentials for  
- make sure you get prompted by your mooltipass   
- do not accept the credentials sending request  
- visit a website B you have credentials for  
- close the tab containing the website A  
- make sure the first prompt is cancelled on the mooltipass  
- make sure another prompt for website B is displayed on the mooltipass  
   