### PR TITLE
fixed microspot test

### DIFF
--- a/sauce_labs_tests/src/test/java/mooltipass/automatedTest/pageObjects/AbstractPage.java
+++ b/sauce_labs_tests/src/test/java/mooltipass/automatedTest/pageObjects/AbstractPage.java
@@ -3,6 +3,8 @@ package mooltipass.automatedTest.pageObjects;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.StaleElementReferenceException;
+import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
@@ -29,6 +31,16 @@ public class AbstractPage {
 		}
 	}
 
+	protected boolean waitUntilClickable(WebElement element) {
+		try {
+			WebDriverWait wait = new WebDriverWait(driver, 12);
+			wait.until(ExpectedConditions.elementToBeClickable(element));
+		} catch (TimeoutException | NoSuchElementException | StaleElementReferenceException e) {
+			return false;
+		}
+		return true;
+	}
+	
 	protected boolean isElementPresent(By by) {
 		try {
 			driver.findElement(by);
@@ -87,6 +99,21 @@ public class AbstractPage {
 
 		JavascriptExecutor executor = (JavascriptExecutor) driver;
 		executor.executeScript("arguments[0].click();", element);
+	}
+	
+	protected void scrollDown(int value) {
+		JavascriptExecutor jse = (JavascriptExecutor) driver;
+		jse.executeScript("window.scrollBy(0,arguments[0])", value);
+	}
+	
+	protected boolean waitUntilNotVisible(By by) {
+		try {
+			WebDriverWait wait = new WebDriverWait(driver, 12);
+			wait.until(ExpectedConditions.invisibilityOfElementLocated(by));
+		} catch (TimeoutException | NoSuchElementException e) {
+			return false;
+		}
+		return true;
 	}
 }
 

--- a/sauce_labs_tests/src/test/java/mooltipass/automatedTest/pageObjects/Microspot.java
+++ b/sauce_labs_tests/src/test/java/mooltipass/automatedTest/pageObjects/Microspot.java
@@ -8,9 +8,9 @@ import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
 
-public class Microspot extends AbstractPage{
-	
-	public Microspot (WebDriver driver) {
+public class Microspot extends AbstractPage {
+
+	public Microspot(WebDriver driver) {
 		super(driver);
 		PageFactory.initElements(driver, this);
 	}
@@ -23,51 +23,64 @@ public class Microspot extends AbstractPage{
 
 	@FindBy(xpath = "//button[.//span[contains(text(),'Anmelden')]]")
 	private WebElement submitLogin;
-	
 
 	@FindBy(xpath = "//span[text()='Mein Konto']")
 	private WebElement loginBtn;
-	
-	@FindBy(xpath = "(//button[.//span[contains(text(),'Abmelden')]])[2]")
+
+	@FindBy(xpath = "(//button[contains(@class,'Xp')])[1]")
 	private WebElement logoutBtn;
-	
 
+	@FindBy(xpath = "//span[text()='Mein Konto']")
+	private WebElement logoutMenu;
 
+	@FindBy(xpath = "//span[contains(text(),'Suchen')]")
+	private WebElement searchBar;
 
-	public void enterEmail(String value){
+	public void enterEmail(String value) {
 		waitUntilAppears(email);
 		email.sendKeys(value);
 	}
-	
-	public void enterPassword(String value){
+
+	public void enterPassword(String value) {
 
 		waitUntilAppears(password);
 		password.sendKeys(value);
 	}
-	
-	public void goToLogin(){
-		waitUntilAppears(loginBtn);		
+
+	public void goToLogin() {
+		if (isElementPresent(By.xpath("//buttton[contains(@class,'Xpqhts')]"))) {
+			waitUntilNotVisible(By.xpath("//buttton[contains(@class,'Xpqhts')]"));
+		}
+
+		waitUntilAppears(loginBtn);
 		Actions action = new Actions(driver);
 		action.moveToElement(loginBtn);
 		action.perform();
+
 	}
-	
-	public void submit(){
-	submitLogin.click();
+
+	public void submit() {
+		submitLogin.click();
 	}
-	
-	public void logout(){
+
+	public void logout() {
+
+		waitUntilClickable(logoutMenu);
+		logoutMenu.click();
 		waitUntilAppears(logoutBtn);
 		logoutBtn.click();
-		sleep(10000);
+
 	}
-	public boolean checkLogin(){
+
+	public boolean checkLogin() {
 
 		waitUntilAppears(By.xpath("//button[.//span[contains(text(),'Abmelden')]]"));
 		return isElementPresent(By.xpath("//button[.//span[contains(text(),'Abmelden')]]"));
 	}
-	public boolean checkAtLoginPage(){
+
+	public boolean checkAtLoginPage() {
+		waitUntilAppears(By.id("email"));
 		return isElementPresent(By.id("email"));
 	}
-	
+
 }


### PR DESCRIPTION
Fixes #\<GitHub-issue-number\>.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [ ] This PR is compliant with the contributing guidelines (if not, please describe why): code is fully documented and if possible a .md file is made.
- [ ] The PR text includes a **detailed explanation** (more than 50 chars)
- [ ] I have thoroughly tested my contribution.

\<Description of and rational behind this PR\>

**In case of a PR concerning the Mooltipass extension:**  
The following test procedure should be done, in the following order.  
  
1) Recall functionality test (Mooltipass unlocked):  
- visit a website you have credentials for  
- make sure you get prompted by your mooltipass  
- accept the credentials sending request  
- make sure you are logged in  
  
2) Storage functionality test (Mooltipass unlocked):  
- visit a website you don't have credentials for  
- fill the username and password field, submit  
- make sure the mooltipass prompts you for password storage **once**  
- accept the credentials storage request  
- run test 1) to make sure credentials are correctly stored  
  
3) Cancel functionality test (Mooltipass unlocked):  
- visit a website you have credentials for  
- make sure you get prompted by your mooltipass   
- do not accept the credentials sending request, close the tab  
- make sure the prompt gets removed on the mooltipass  
  
4) Credentials requests queue test (Mooltipass **locked**)  
- visit a website you have credentials for  
- unlock your mooltipass  
- make sure you get prompted by your mooltipass   
  
5) Credentials requests queue test (Mooltipass unlocked)  
- visit a website A you have credentials for  
- make sure you get prompted by your mooltipass   
- do not accept the credentials sending request  
- visit a website B you have credentials for  
- close the tab containing the website A  
- make sure the first prompt is cancelled on the mooltipass  
- make sure another prompt for website B is displayed on the mooltipass  
   